### PR TITLE
allow empty parameters of the devicelink adaptor

### DIFF
--- a/adaptors/dummy/pkg/adaptor/service.go
+++ b/adaptors/dummy/pkg/adaptor/service.go
@@ -63,8 +63,10 @@ func (s *Service) Connect(server api.Connection_ConnectServer) error {
 
 		// validate parameters
 		var parameters physical.Parameters
-		if err := jsoniter.Unmarshal(req.GetParameters(), &parameters); err != nil {
-			return status.Errorf(codes.Internal, "failed to unmarshal parameters: %v", err)
+		if req.Parameters != nil {
+			if err := jsoniter.Unmarshal(req.GetParameters(), &parameters); err != nil {
+				return status.Errorf(codes.Internal, "failed to unmarshal parameters: %v", err)
+			}
 		}
 		if err := parameters.Validate(); err != nil {
 			return status.Errorf(codes.InvalidArgument, "failed to validate parameters: %v", err)

--- a/pkg/suctioncup/neurons.go
+++ b/pkg/suctioncup/neurons.go
@@ -46,8 +46,10 @@ func (m *manager) Send(data *unstructured.Unstructured, by *edgev1alpha1.DeviceL
 	if conn == nil {
 		return errors.Errorf("could not find connection %s", name)
 	}
-
-	var parametersBytes = by.Status.Adaptor.Parameters.DeepCopy().Raw
+	var parametersBytes []byte
+	if by.Status.Adaptor.Parameters != nil {
+		parametersBytes = by.Status.Adaptor.Parameters.DeepCopy().Raw
+	}
 	var dataBytes, err = data.DeepCopy().MarshalJSON()
 	if err != nil {
 		return errors.Wrapf(err, "could not marshal data as JSON")


### PR DESCRIPTION
**Problem**:
if the parameters of the deviceLink adaptor are not set, it will cause nil pointer exception.

**Solution:**
add logic to check to allow empty parameters in the devicelink controller 