### PR TITLE
refactor(adaptors): print log with device namespacedname

### DIFF
--- a/adaptors/ble/pkg/adaptor/service.go
+++ b/adaptors/ble/pkg/adaptor/service.go
@@ -4,6 +4,8 @@ import (
 	"github.com/bettercap/gatt"
 	"github.com/bettercap/gatt/examples/option"
 	jsoniter "github.com/json-iterator/go"
+	uberzap "go.uber.org/zap"
+	uberzapcore "go.uber.org/zap/zapcore"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,7 +23,17 @@ import (
 	"github.com/rancher/octopus/pkg/util/object"
 )
 
-var log = logr.NewDelegatingLogger(zap.New(zap.UseDevMode(true)))
+var log = logr.NewDelegatingLogger(nil)
+
+func init() {
+	log.Fulfill(zap.New(
+		zap.UseDevMode(true),
+		zap.Level(func() *uberzap.AtomicLevel {
+			level := uberzap.NewAtomicLevelAt(uberzapcore.DebugLevel)
+			return &level
+		}()),
+	))
+}
 
 func NewService() *Service {
 	var scheme = k8sruntime.NewScheme()

--- a/adaptors/dummy/pkg/adaptor/service.go
+++ b/adaptors/dummy/pkg/adaptor/service.go
@@ -2,6 +2,8 @@ package adaptor
 
 import (
 	jsoniter "github.com/json-iterator/go"
+	uberzap "go.uber.org/zap"
+	uberzapcore "go.uber.org/zap/zapcore"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -9,9 +11,8 @@ import (
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
 	logr "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/rancher/octopus/adaptors/dummy/api/v1alpha1"
 	"github.com/rancher/octopus/adaptors/dummy/pkg/physical"
@@ -20,7 +21,17 @@ import (
 	"github.com/rancher/octopus/pkg/util/object"
 )
 
-var log = logr.NewDelegatingLogger(zap.New(zap.UseDevMode(true)))
+var log = logr.NewDelegatingLogger(nil)
+
+func init() {
+	log.Fulfill(zap.New(
+		zap.UseDevMode(true),
+		zap.Level(func() *uberzap.AtomicLevel {
+			level := uberzap.NewAtomicLevelAt(uberzapcore.DebugLevel)
+			return &level
+		}()),
+	))
+}
 
 func NewService() *Service {
 	var scheme = k8sruntime.NewScheme()

--- a/adaptors/modbus/pkg/adaptor/service.go
+++ b/adaptors/modbus/pkg/adaptor/service.go
@@ -2,11 +2,8 @@ package adaptor
 
 import (
 	jsoniter "github.com/json-iterator/go"
-	"github.com/rancher/octopus/adaptors/modbus/api/v1alpha1"
-	"github.com/rancher/octopus/adaptors/modbus/pkg/physical"
-	api "github.com/rancher/octopus/pkg/adaptor/api/v1alpha1"
-	"github.com/rancher/octopus/pkg/adaptor/connection"
-	"github.com/rancher/octopus/pkg/util/object"
+	uberzap "go.uber.org/zap"
+	uberzapcore "go.uber.org/zap/zapcore"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,9 +13,25 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	logr "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/rancher/octopus/adaptors/modbus/api/v1alpha1"
+	"github.com/rancher/octopus/adaptors/modbus/pkg/physical"
+	api "github.com/rancher/octopus/pkg/adaptor/api/v1alpha1"
+	"github.com/rancher/octopus/pkg/adaptor/connection"
+	"github.com/rancher/octopus/pkg/util/object"
 )
 
-var log = logr.NewDelegatingLogger(zap.New(zap.UseDevMode(true)))
+var log = logr.NewDelegatingLogger(nil)
+
+func init() {
+	log.Fulfill(zap.New(
+		zap.UseDevMode(true),
+		zap.Level(func() *uberzap.AtomicLevel {
+			level := uberzap.NewAtomicLevelAt(uberzapcore.DebugLevel)
+			return &level
+		}()),
+	))
+}
 
 func NewService() *Service {
 	var scheme = k8sruntime.NewScheme()

--- a/adaptors/opcua/pkg/adaptor/service.go
+++ b/adaptors/opcua/pkg/adaptor/service.go
@@ -2,11 +2,8 @@ package adaptor
 
 import (
 	jsoniter "github.com/json-iterator/go"
-	"github.com/rancher/octopus/adaptors/opcua/api/v1alpha1"
-	"github.com/rancher/octopus/adaptors/opcua/pkg/physical"
-	api "github.com/rancher/octopus/pkg/adaptor/api/v1alpha1"
-	"github.com/rancher/octopus/pkg/adaptor/connection"
-	"github.com/rancher/octopus/pkg/util/object"
+	uberzap "go.uber.org/zap"
+	uberzapcore "go.uber.org/zap/zapcore"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,9 +13,25 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	logr "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/rancher/octopus/adaptors/opcua/api/v1alpha1"
+	"github.com/rancher/octopus/adaptors/opcua/pkg/physical"
+	api "github.com/rancher/octopus/pkg/adaptor/api/v1alpha1"
+	"github.com/rancher/octopus/pkg/adaptor/connection"
+	"github.com/rancher/octopus/pkg/util/object"
 )
 
-var log = logr.NewDelegatingLogger(zap.New(zap.UseDevMode(true)))
+var log = logr.NewDelegatingLogger(nil)
+
+func init() {
+	log.Fulfill(zap.New(
+		zap.UseDevMode(true),
+		zap.Level(func() *uberzap.AtomicLevel {
+			level := uberzap.NewAtomicLevelAt(uberzapcore.DebugLevel)
+			return &level
+		}()),
+	))
+}
 
 func NewService() *Service {
 	var scheme = k8sruntime.NewScheme()

--- a/hack/make-rules/template-adaptor.sh
+++ b/hack/make-rules/template-adaptor.sh
@@ -45,6 +45,7 @@ function entry() {
   sed "s#adaptors.edge.cattle.io/template#adaptors.edge.cattle.io/${adaptorNameLowercase}#g" "${adaptorPath}/pkg/template/template.go" >"${tmpfile}" && mv "${tmpfile}" "${adaptorPath}/pkg/template/template.go"
   sed "s#template.socket#${adaptorNameLowercase}.socket#g" "${adaptorPath}/pkg/template/template.go" >"${tmpfile}" && mv "${tmpfile}" "${adaptorPath}/pkg/template/template.go"
   sed "s#package template#package ${adaptorNameLowercase}#g" "${adaptorPath}/pkg/template/template.go" >"${tmpfile}" && mv "${tmpfile}" "${adaptorPath}/pkg/template/template.go"
+  sed "s#templatedevices#${adaptorNameLowercase}devices#g" "${adaptorPath}/pkg/template/template.go" >"${tmpfile}" && mv "${tmpfile}" "${adaptorPath}/pkg/template/template.go"
   mv "${adaptorPath}/pkg/template/template.go" "${adaptorPath}/pkg/template/${adaptorNameLowercase}.go"
   mv "${adaptorPath}/pkg/template" "${adaptorPath}/pkg/${adaptorNameLowercase}"
 

--- a/template/adaptor/pkg/adaptor/service.go
+++ b/template/adaptor/pkg/adaptor/service.go
@@ -1,18 +1,34 @@
 package adaptor
 
 import (
+	uberzap "go.uber.org/zap"
+	uberzapcore "go.uber.org/zap/zapcore"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	logr "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	api "github.com/rancher/octopus/pkg/adaptor/api/v1alpha1"
 	"github.com/rancher/octopus/template/adaptor/api/v1alpha1"
 )
 
+var log = logr.NewDelegatingLogger(nil)
+
+func init() {
+	log.Fulfill(zap.New(
+		zap.UseDevMode(true),
+		zap.Level(func() *uberzap.AtomicLevel {
+			level := uberzap.NewAtomicLevelAt(uberzapcore.DebugLevel)
+			return &level
+		}()),
+	))
+}
+
 func NewService() *Service {
 	var scheme = k8sruntime.NewScheme()
-	//
+	// register v1alpha1 scheme into runtime scheme.
 	utilruntime.Must(v1alpha1.AddToScheme(scheme))
 
 	return &Service{


### PR DESCRIPTION
<!-- [1] Please search for existing PR first, the duplicate PR may not be received.
If the PR has the same fix/enhancement as other, please related them together and explain in step [5].
-->

<!-- [2] Please do not create a PR without creating an issue first.
List issues to be fixed.
-->
**Fixes:**
https://github.com/cnrancher/octopus/issues/63

<!-- [3] Describe what the PR fixes or enhances. -->
**Problem:**
The current adaptor's log can not print the device namespaced name.

<!-- [4] Describe what the PR does. -->
**Solution:**
 - Use `Fullfill` instead of `NewDelegatingLogger`.

<!-- [5] Describe the plan for regression testing, if no, just write "None" in here.-->
**Test plan:**
None
