### PR TITLE
fix: release socket file when crashing

### DIFF
--- a/pkg/adaptor/api/v1alpha1/constants.go
+++ b/pkg/adaptor/api/v1alpha1/constants.go
@@ -1,14 +1,6 @@
 package v1alpha1
 
 const (
-	// Healthy means that the adaptor is healthy
-	Healthy = "Healthy"
-
-	// Unhealthy means that the adaptor is unhealthy
-	Unhealthy = "Unhealthy"
-)
-
-const (
 	// Version is the current version of the API supported by Limb
 	Version = "v1alpha1"
 

--- a/pkg/adaptor/connection/serve.go
+++ b/pkg/adaptor/connection/serve.go
@@ -1,12 +1,48 @@
 package connection
 
 import (
+	"os"
+	"path/filepath"
+
 	api "github.com/rancher/octopus/pkg/adaptor/api/v1alpha1"
 )
 
 // Serve provides the connection service `svc` on /var/lib/octopus/adaptors/`endpoint`,
-// and is affected by `stop` chan
+// and is affected by `stop` chan.
 func Serve(endpoint string, svc api.ConnectionServer, stop <-chan struct{}) error {
-	var srv = NewServer(endpoint, svc)
+	var srv = NewServer(endpoint, releaseSocket(endpoint, svc))
 	return srv.Start(stop)
+}
+
+// releaseSocket wraps the ConnectionServer instance as releaseSocketServer.
+func releaseSocket(endpoint string, svc api.ConnectionServer) *releaseSocketServer {
+	return &releaseSocketServer{
+		endpoint: endpoint,
+		svc:      svc,
+	}
+}
+
+// releaseSocketServer decorates the Connect method of ConnectionServer to release the socket file when crashed,
+// but panic still continue.
+type releaseSocketServer struct {
+	endpoint string
+	svc      api.ConnectionServer
+}
+
+func (s *releaseSocketServer) Connect(server api.Connection_ConnectServer) error {
+	defer func() {
+		if r := recover(); r != nil {
+			var socketPath = filepath.Join(api.AdaptorPath, s.endpoint)
+			if pi, err := os.Stat(socketPath); err == nil && !pi.IsDir() && pi.Mode()&os.ModeSocket != 0 {
+				_ = os.RemoveAll(socketPath)
+			}
+
+			// NB(thxCode) the purpose in this recover is to clean up the remaining socket file,
+			// which ensure the adaptor can be restarted again. For irreversible panic,
+			// returning an error is unable to solve the internal problem, and may lead to other serious errors.
+			// So just panic to upper level.
+			panic(r)
+		}
+	}()
+	return s.svc.Connect(server)
 }


### PR DESCRIPTION
<!-- [1] Please search for existing PR first, the duplicate PR may not be received.
If the PR has the same fix/enhancement as other, please related them together and explain in step [5].
-->

<!-- [2] Please do not create a PR without creating an issue first.
List issues to be fixed.
-->
**Fixes:** 

#65 

<!-- [3] Describe what the PR fixes or enhances. -->
**Problem:**

Cannot restart the adaptor (not just dummy) again after crashed as the adaptor socket file has not been released.

<!-- [4] Describe what the PR does. -->
**Solution:**

Releasing the socket file in a recovering block.

<!-- [5] Describe the plan for regression testing, if no, just write "None" in here.-->
**Test plan:**

Replay the steps of issues, it's worth to notice that PR https://github.com/cnrancher/octopus/pull/62 has changed the `DummyDevice` to `DummySpecialDevice`.
