### PR TITLE
fix: allow for modbus device protocol config changing

### DIFF
--- a/adaptors/modbus/pkg/adaptor/service.go
+++ b/adaptors/modbus/pkg/adaptor/service.go
@@ -115,6 +115,7 @@ func (s *Service) Connect(server api.Connection_ConnectServer) error {
 			var modbusHandler, err = physical.NewModbusHandler(modbus.Spec.ProtocolConfig, parameters.Timeout)
 			if err != nil {
 				log.Error(err, "Failed to connect to modbus device endpoint")
+				return status.Errorf(codes.FailedPrecondition, "failed to connect to modbus device endpoint: %v", err)
 			}
 
 			device = physical.NewDevice(
@@ -122,7 +123,7 @@ func (s *Service) Connect(server api.Connection_ConnectServer) error {
 				deviceName,
 				dataHandler,
 				modbusHandler,
-				parameters.SyncInterval,
+				parameters,
 				modbus.Spec,
 			)
 


### PR DESCRIPTION
<!-- [1] Please search for existing PR first, the duplicate PR may not be received.
If the PR has the same fix/enhancement as other, please related them together and explain in step [5].
-->

<!-- [2] Please do not create a PR without creating an issue first.
List issues to be fixed.
-->
**Fixes:**
https://github.com/cnrancher/octopus/issues/84

<!-- [3] Describe what the PR fixes or enhances. -->
**Problem:**
If we change `spec.protocol.tcp.ip` from `devicelink` with a connected device, the adaptor is still connecting to the old modbus device

<!-- [4] Describe what the PR does. -->
**Solution:**
Configure protocol config if it is not deep equal to the old config during each device configuration.

<!-- [5] Describe the plan for regression testing, if no, just write "None" in here.-->
**Test plan:**
1. start a modbus device
1. create a modbus tcp `devicelink` and wait for the device connected
1. start another modbus device
1. change `spec.protocol.tcp` from the `devicelink` to the new device's address
1. check whether the adaptor is connecting to the new device instead

