### PR TITLE
fix: If the MQTT broker link fails or times out, no error is returned to DeviceLink

### DIFF
--- a/adaptors/mqtt/api/v1alpha1/mqttdevice_types.go
+++ b/adaptors/mqtt/api/v1alpha1/mqttdevice_types.go
@@ -35,8 +35,8 @@ type QosType int
 
 type MqttConfig struct {
 	Broker   string `json:"broker"`
-	Username string `json:"username"`
-	Password string `json:"password"`
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
 }
 
 type SubInfo struct {

--- a/adaptors/mqtt/deploy/e2e/all_in_one.yaml
+++ b/adaptors/mqtt/deploy/e2e/all_in_one.yaml
@@ -51,8 +51,6 @@ spec:
                     type: string
                 required:
                 - broker
-                - password
-                - username
                 type: object
               properties:
                 items:

--- a/adaptors/mqtt/deploy/manifests/crd/base/devices.edge.cattle.io_mqttdevices.yaml
+++ b/adaptors/mqtt/deploy/manifests/crd/base/devices.edge.cattle.io_mqttdevices.yaml
@@ -46,8 +46,6 @@ spec:
                     type: string
                 required:
                 - broker
-                - password
-                - username
                 type: object
               properties:
                 items:

--- a/adaptors/mqtt/pkg/adaptor/service.go
+++ b/adaptors/mqtt/pkg/adaptor/service.go
@@ -102,6 +102,7 @@ func (s *Service) Connect(server api.Connection_ConnectServer) error {
 
 			mqttClient, err := physical.NewMqttClient(mqtt.Name, mqtt.Spec.Config)
 			if err != nil {
+				log.Error(err, "connect receive new device NewMqttClient error")
 				return status.Errorf(codes.InvalidArgument, "failed to connect mqtt: %v", err)
 			}
 
@@ -113,7 +114,8 @@ func (s *Service) Connect(server api.Connection_ConnectServer) error {
 			)
 
 			go device.On()
-			log.Info("connect recve new device success", "name", mqtt.Name)
+
+			log.Info("connect receive new device success", "name", mqtt.Name)
 
 		} else {
 			device.Configure(&mqtt.Spec)

--- a/adaptors/mqtt/pkg/physical/converter_test.go
+++ b/adaptors/mqtt/pkg/physical/converter_test.go
@@ -58,12 +58,12 @@ func TestConvertToStatusProperty(t *testing.T) {
 		"simple": {
 			input:    simpleData,
 			jsonPath: "store.bicycle.price",
-			want:     []byte(`{"apiVersion":"devices.edge.cattle.io/v1alpha1","kind":"MqttDevice","metadata":{"creationTimestamp":null,"name":"testDevice"},"spec":{"config":{"broker":"","password":"","username":""},"properties":[{"description":"test property","jsonPath":"store.bicycle.price","name":"test_property","pubInfo":{"qos":0,"topic":""},"subInfo":{"payloadType":"json","qos":2,"topic":"test/abc"},"value":{"valueType":""}}]},"status":{"properties":[{"description":"test property","name":"test_property","updateAt":"2020-01-01T01:01:01Z","value":{"floatValue":"19.950000","valueType":"float"}}]}}`),
+			want:     []byte(`{"apiVersion":"devices.edge.cattle.io/v1alpha1","kind":"MqttDevice","metadata":{"creationTimestamp":null,"name":"testDevice"},"spec":{"config":{"broker":""},"properties":[{"description":"test property","jsonPath":"store.bicycle.price","name":"test_property","pubInfo":{"qos":0,"topic":""},"subInfo":{"payloadType":"json","qos":2,"topic":"test/abc"},"value":{"valueType":""}}]},"status":{"properties":[{"description":"test property","name":"test_property","updateAt":"2020-01-01T01:01:01Z","value":{"floatValue":"19.950000","valueType":"float"}}]}}`),
 		},
 		"room light": {
 			input:    roomLightData,
 			jsonPath: "power",
-			want:     []byte(`{"apiVersion":"devices.edge.cattle.io/v1alpha1","kind":"MqttDevice","metadata":{"creationTimestamp":null,"name":"testDevice"},"spec":{"config":{"broker":"","password":"","username":""},"properties":[{"description":"test property","jsonPath":"power","name":"test_property","pubInfo":{"qos":0,"topic":""},"subInfo":{"payloadType":"json","qos":2,"topic":"test/abc"},"value":{"valueType":""}}]},"status":{"properties":[{"description":"test property","name":"test_property","updateAt":"2020-01-01T01:01:01Z","value":{"objectValue":{"electricQuantity":19.99,"powerDissipation":"10KWH"},"valueType":"object"}}]}}`),
+			want:     []byte(`{"apiVersion":"devices.edge.cattle.io/v1alpha1","kind":"MqttDevice","metadata":{"creationTimestamp":null,"name":"testDevice"},"spec":{"config":{"broker":""},"properties":[{"description":"test property","jsonPath":"power","name":"test_property","pubInfo":{"qos":0,"topic":""},"subInfo":{"payloadType":"json","qos":2,"topic":"test/abc"},"value":{"valueType":""}}]},"status":{"properties":[{"description":"test property","name":"test_property","updateAt":"2020-01-01T01:01:01Z","value":{"objectValue":{"electricQuantity":19.99,"powerDissipation":"10KWH"},"valueType":"object"}}]}}`),
 		},
 	}
 


### PR DESCRIPTION
<!-- [1] Please search for existing PR first, the duplicate PR may not be received.
If the PR has the same fix/enhancement as other, please related them together and explain in step [5].
-->

<!-- [2] Please do not create a PR without creating an issue first.
List issues to be fixed.
-->
**Fixes:**
If the MQTT broker link fails or times out, no error is returned to DeviceLink

<!-- [3] Describe what the PR fixes or enhances. -->
**Problem:**
When creating a devicelink, adaptor will go ahead and create a device and link the Mqtt broker, if the link fails.devicelink will show unhealthy, this bug As a result, the link failed, but devicelink still shows health

<!-- [4] Describe what the PR does. -->
**Solution:**
1. change spec config mqtt username and password  field to  not required.
2. When the limb link adaptor fails to create a link to the Matt broker, an error is immediately returned when the adaptor creates a link to the Matt broker

<!-- [5] Describe the plan for regression testing, if no, just write "None" in here.-->
**Test plan:**
1.install octopus
2.apply mqtt adaptor e2e all_in_one.yaml
3.change e2e roomlightcase.yaml spec mqtt config to an error broker
4.check the DeviceLink status. 
