### PR TITLE
fix: failed to delete devicelink if not node/model

### DIFF
--- a/pkg/brain/controller/node.go
+++ b/pkg/brain/controller/node.go
@@ -70,7 +70,7 @@ func (r *NodeReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			}
 		}
 
-		// removesfinalizer
+		// removes finalizer
 		node.Finalizers = collection.StringSliceRemove(node.Finalizers, ReconcilingNode)
 		if err := r.Update(ctx, &node); err != nil {
 			log.Error(err, "Unable to remove finalizer from Node")

--- a/pkg/limb/controller/devicelink.go
+++ b/pkg/limb/controller/devicelink.go
@@ -67,20 +67,6 @@ func (r *DeviceLinkReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 		return ctrl.Result{}, nil
 	}
 
-	// rejects if not the requested node
-	if link.Status.NodeName != r.NodeName {
-		// NB(thxCode) disconnects the link to avoid connection leak when the requested node has been changed
-		r.SuctionCup.Disconnect(&link)
-		return ctrl.Result{}, nil
-	}
-
-	// rejects if the conditions are not met
-	if devicelink.GetModelExistedStatus(&link.Status) != metav1.ConditionTrue {
-		// NB(thxCode) disconnects the link to avoid connection leak when the model has been changed or removed
-		r.SuctionCup.Disconnect(&link)
-		return ctrl.Result{}, nil
-	}
-
 	if object.IsDeleted(&link) {
 		if !collection.StringSliceContain(link.Finalizers, ReconcilingDeviceLink) {
 			return ctrl.Result{}, nil
@@ -96,6 +82,20 @@ func (r *DeviceLinkReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 			return ctrl.Result{Requeue: true}, nil
 		}
 
+		return ctrl.Result{}, nil
+	}
+
+	// rejects if not the requested node
+	if link.Status.NodeName != r.NodeName {
+		// NB(thxCode) disconnects the link to avoid connection leak when the requested node has been changed
+		r.SuctionCup.Disconnect(&link)
+		return ctrl.Result{}, nil
+	}
+
+	// rejects if the conditions are not met
+	if devicelink.GetModelExistedStatus(&link.Status) != metav1.ConditionTrue {
+		// NB(thxCode) disconnects the link to avoid connection leak when the model has been changed or removed
+		r.SuctionCup.Disconnect(&link)
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
<!-- [1] Please search for existing PR first, the duplicate PR may not be received.
If the PR has the same fix/enhancement as other, please related them together and explain in step [5].
-->

<!-- [2] Please do not create a PR without creating an issue first.
List issues to be fixed.
-->
**Fixes:**

#87

<!-- [3] Describe what the PR fixes or enhances. -->
**Problem:**

Since the `edge.cattle.io/octopus-limb` finalizer could not be deleted which created by `limb`,  so we cannot delete the DeviceLink instance until removed the finalizer. 

<!-- [4] Describe what the PR does. -->
**Solution:**

- In `limb` reconciling, move the clean up job of deleted DeviceLink instance to the top, so the deleted event will handle ASAP.
- In `brain` reconciling, if confirmed the Node doesn't exist during deleting, the `brain` can take over to remove the finalizer of DeviceLink.


<!-- [5] Describe the plan for regression testing, if no, just write "None" in here.-->
**Test plan:**

Replay the steps described in #87.
