### PR TITLE
refactor: adjust the socket suffix

### DIFF
--- a/adaptors/ble/README.md
+++ b/adaptors/ble/README.md
@@ -6,7 +6,7 @@ This is BLE(Bluetooth Low Energy) adaptor is used for bluetooth devices connecti
 
 |  Versions | Register Name | Endpoint Socket | Available |
 |:---:|:---:|:---:|:---:|
-|  `v1alpha1` | `adaptors.edge.cattle.io/ble` | `ble.socket` | * |
+|  `v1alpha1` | `adaptors.edge.cattle.io/ble` | `ble.sock` | * |
 
 ## Support Model
 

--- a/adaptors/ble/pkg/ble/ble.go
+++ b/adaptors/ble/pkg/ble/ble.go
@@ -13,7 +13,7 @@ import (
 const (
 	Name     = "adaptors.edge.cattle.io/ble"
 	Version  = "v1alpha1"
-	Endpoint = "ble.socket"
+	Endpoint = "ble.sock"
 )
 
 // +kubebuilder:rbac:groups=devices.edge.cattle.io,resources=bluetoothdevices,verbs=get;list;watch;create;update;patch;delete

--- a/adaptors/dummy/README.md
+++ b/adaptors/dummy/README.md
@@ -28,7 +28,7 @@ This is for experience or testing.
 
 |  Versions | Register Name | Endpoint Socket | Available |
 |:---:|:---:|:---:|:---:|
-|  `v1alpha1` | `adaptors.edge.cattle.io/dummy` | `dummy.socket` | * |
+|  `v1alpha1` | `adaptors.edge.cattle.io/dummy` | `dummy.sock` | * |
 
 ## Support Model
 

--- a/adaptors/dummy/pkg/dummy/dummy.go
+++ b/adaptors/dummy/pkg/dummy/dummy.go
@@ -14,7 +14,7 @@ import (
 const (
 	Name     = "adaptors.edge.cattle.io/dummy"
 	Version  = "v1alpha1"
-	Endpoint = "dummy.socket"
+	Endpoint = "dummy.sock"
 )
 
 // +kubebuilder:rbac:groups=devices.edge.cattle.io,resources=dummyspecialdevices,verbs=get;list;watch;create;update;patch;delete

--- a/adaptors/modbus/README.md
+++ b/adaptors/modbus/README.md
@@ -9,7 +9,7 @@ Modbus Adaptor supports TCP and RTU protocol.
 
 |  Versions | Register Name | Endpoint Socket | Available |
 |:---:|:---:|:---:|:---:|
-|  `v1alpha1` | `adaptors.edge.cattle.io/modbus` | `modbus.socket` | * |
+|  `v1alpha1` | `adaptors.edge.cattle.io/modbus` | `modbus.sock` | * |
 
 ## Support Model
 

--- a/adaptors/modbus/pkg/modbus/modbus.go
+++ b/adaptors/modbus/pkg/modbus/modbus.go
@@ -14,7 +14,7 @@ import (
 const (
 	Name     = "adaptors.edge.cattle.io/modbus"
 	Version  = "v1alpha1"
-	Endpoint = "modbus.socket"
+	Endpoint = "modbus.sock"
 )
 
 // +kubebuilder:rbac:groups=devices.edge.cattle.io,resources=modbusdevices,verbs=get;list;watch;create;update;patch;delete

--- a/adaptors/mqtt/README.md
+++ b/adaptors/mqtt/README.md
@@ -6,7 +6,7 @@
 
 |  Versions | Register Name | Endpoint Socket | Available |
 |:---:|:---:|:---:|:---:|
-|  `v1alpha1` | `adaptors.edge.cattle.io/mqtt` | `mqtt.socket` | * |
+|  `v1alpha1` | `adaptors.edge.cattle.io/mqtt` | `mqtt.sock` | * |
 
 ## Support Model
 

--- a/adaptors/mqtt/pkg/mqtt/mqtt.go
+++ b/adaptors/mqtt/pkg/mqtt/mqtt.go
@@ -14,7 +14,7 @@ import (
 const (
 	Name     = "adaptors.edge.cattle.io/mqtt"
 	Version  = "v1alpha1"
-	Endpoint = "mqtt.socket"
+	Endpoint = "mqtt.sock"
 )
 
 // +kubebuilder:rbac:groups=devices.edge.cattle.io,resources=mqttdevices,verbs=get;list;watch;create;update;patch;delete

--- a/adaptors/opcua/README.md
+++ b/adaptors/opcua/README.md
@@ -8,7 +8,7 @@ OPCUA Adaptor is used for connecting to and manipulating opcua devices on the ed
 
 |  Versions | Register Name | Endpoint Socket | Available |
 |:---:|:---:|:---:|:---:|
-|  `v1alpha1` | `adaptors.edge.cattle.io/opcua` | `opcua.socket` | * |
+|  `v1alpha1` | `adaptors.edge.cattle.io/opcua` | `opcua.sock` | * |
 
 ## Support Model
 

--- a/adaptors/opcua/pkg/opcua/opcua.go
+++ b/adaptors/opcua/pkg/opcua/opcua.go
@@ -14,7 +14,7 @@ import (
 const (
 	Name     = "adaptors.edge.cattle.io/opcua"
 	Version  = "v1alpha1"
-	Endpoint = "opcua.socket"
+	Endpoint = "opcua.sock"
 )
 
 // +kubebuilder:rbac:groups=devices.edge.cattle.io,resources=opcuadevices,verbs=get;list;watch;create;update;patch;delete

--- a/docs/adaptors/design_of_adaptor.md
+++ b/docs/adaptors/design_of_adaptor.md
@@ -106,7 +106,7 @@ Following the below steps can allow an adaptor to interact with `limb`:
         string name = 1;
         // Version of the API the adaptor was built against.
         string version = 2;
-        // Name of the unix socket the adaptor is listening on, it's in the form `*.socket`.
+        // Name of the unix socket the adaptor is listening on, it's in the form `*.sock`.
         string endpoint = 3;
     }
     ```
@@ -137,7 +137,7 @@ Following the below steps can allow an adaptor to interact with `limb`:
         bytes device = 1;
     }
     ```
-1. The adaptor registers itself with the `limb` through the Unix socket at host path `/var/lib/octopus/adaptors/limb.socket`.
+1. The adaptor registers itself with the `limb` through the Unix socket at host path `/var/lib/octopus/adaptors/limb.sock`.
 1. After successfully registering itself, the adaptor runs in serving mode, during which it keeps connecting devices and reports back to the `limb` upon any device state changes.
 
 #### Registration

--- a/hack/make-rules/template-adaptor.sh
+++ b/hack/make-rules/template-adaptor.sh
@@ -43,7 +43,7 @@ function entry() {
   sed "s#template/adaptor#adaptors/${adaptorNameLowercase}#g" "${adaptorPath}/pkg/adaptor/service.go" >"${tmpfile}" && mv "${tmpfile}" "${adaptorPath}/pkg/adaptor/service.go"
   sed "s#template/adaptor#adaptors/${adaptorNameLowercase}#g" "${adaptorPath}/pkg/template/template.go" >"${tmpfile}" && mv "${tmpfile}" "${adaptorPath}/pkg/template/template.go"
   sed "s#adaptors.edge.cattle.io/template#adaptors.edge.cattle.io/${adaptorNameLowercase}#g" "${adaptorPath}/pkg/template/template.go" >"${tmpfile}" && mv "${tmpfile}" "${adaptorPath}/pkg/template/template.go"
-  sed "s#template.socket#${adaptorNameLowercase}.socket#g" "${adaptorPath}/pkg/template/template.go" >"${tmpfile}" && mv "${tmpfile}" "${adaptorPath}/pkg/template/template.go"
+  sed "s#template.sock#${adaptorNameLowercase}.sock#g" "${adaptorPath}/pkg/template/template.go" >"${tmpfile}" && mv "${tmpfile}" "${adaptorPath}/pkg/template/template.go"
   sed "s#package template#package ${adaptorNameLowercase}#g" "${adaptorPath}/pkg/template/template.go" >"${tmpfile}" && mv "${tmpfile}" "${adaptorPath}/pkg/template/template.go"
   sed "s#templatedevices#${adaptorNameLowercase}devices#g" "${adaptorPath}/pkg/template/template.go" >"${tmpfile}" && mv "${tmpfile}" "${adaptorPath}/pkg/template/template.go"
   mv "${adaptorPath}/pkg/template/template.go" "${adaptorPath}/pkg/template/${adaptorNameLowercase}.go"

--- a/pkg/adaptor/api/v1alpha1/api.pb.go
+++ b/pkg/adaptor/api/v1alpha1/api.pb.go
@@ -85,7 +85,7 @@ type RegisterRequest struct {
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// Version of the API the adaptor was built against.
 	Version string `protobuf:"bytes,2,opt,name=version,proto3" json:"version,omitempty"`
-	// Name of the unix socket the adaptor is listening on, it's in the form `*.socket`.
+	// Name of the unix socket the adaptor is listening on, it's in the form `*.sock`.
 	Endpoint string `protobuf:"bytes,3,opt,name=endpoint,proto3" json:"endpoint,omitempty"`
 }
 

--- a/pkg/adaptor/api/v1alpha1/api.proto
+++ b/pkg/adaptor/api/v1alpha1/api.proto
@@ -28,7 +28,7 @@ message RegisterRequest {
     string name = 1;
     // Version of the API the adaptor was built against.
     string version = 2;
-    // Name of the unix socket the adaptor is listening on, it's in the form `*.socket`.
+    // Name of the unix socket the adaptor is listening on, it's in the form `*.sock`.
     string endpoint = 3;
 }
 

--- a/pkg/adaptor/api/v1alpha1/constants.go
+++ b/pkg/adaptor/api/v1alpha1/constants.go
@@ -8,7 +8,7 @@ const (
 	AdaptorPath = "/var/lib/octopus/adaptors/"
 
 	// SocketSuffix is the suffix of the socket
-	SocketSuffix = ".socket"
+	SocketSuffix = ".sock"
 
 	// LimbSocket is the path of the Limb registry socket
 	LimbSocket = AdaptorPath + "limb" + SocketSuffix

--- a/template/adaptor/README.md
+++ b/template/adaptor/README.md
@@ -6,7 +6,7 @@
 
 |  Versions | Register Name | Endpoint Socket | Available |
 |:---:|:---:|:---:|:---:|
-|  `v1alpha1` | `adaptors.edge.cattle.io/template` | `template.socket` | * |
+|  `v1alpha1` | `adaptors.edge.cattle.io/template` | `template.sock` | * |
 
 ## Support Model
 

--- a/template/adaptor/pkg/template/template.go
+++ b/template/adaptor/pkg/template/template.go
@@ -14,7 +14,7 @@ import (
 const (
 	Name     = "adaptors.edge.cattle.io/template"
 	Version  = "v1alpha1"
-	Endpoint = "template.socket"
+	Endpoint = "template.sock"
 )
 
 // +kubebuilder:rbac:groups=devices.edge.cattle.io,resources=templatedevices,verbs=get;list;watch;create;update;patch;delete

--- a/test/integration/limb/devicelink_controller_test.go
+++ b/test/integration/limb/devicelink_controller_test.go
@@ -242,7 +242,7 @@ func (a fakeDummyAdaptor) GetName() string {
 }
 
 func (a fakeDummyAdaptor) GetEndpoint() string {
-	return "dummy.socket"
+	return "dummy.sock"
 }
 
 func (a fakeDummyAdaptor) Stop() error {


### PR DESCRIPTION
<!-- [1] Please search for existing PR first, the duplicate PR may not be received.
If the PR has the same fix/enhancement as other, please related them together and explain in step [5].
-->

<!-- [2] Please do not create a PR without creating an issue first.
List issues to be fixed.
-->
**Fixes:**

#92

<!-- [3] Describe what the PR fixes or enhances. -->
**Problem:**

Usually, the socket file names are suffixed with .sock.

<!-- [4] Describe what the PR does. -->
**Solution:**

Refactor all socket file name from *.socket to *.sock.

<!-- [5] Describe the plan for regression testing, if no, just write "None" in here.-->
**Test plan:**

1. Create a Kubernetes cluster with `cluster-k3d-spinup.sh` script.
1. Deploy Octopus.
1. Deploy dummy/modbus/mqtt/ble/opcua adaptor, and then verify if the following files exist on each Node:
    - [x] /var/lib/octopus/adaptors/limb.sock
    - [x] /var/lib/octopus/adaptors/{adaptor}.sock
1. Undeploy dummy/modbus/mqtt/ble/opcua adaptor, and then verify if the following files don't exist on each Node:
    - [x] /var/lib/octopus/adaptors/{adaptor}.sock

