### PR TITLE
feat(adaptors): support log parameterization

### DIFF
--- a/adaptors/ble/cmd/ble/main.go
+++ b/adaptors/ble/cmd/ble/main.go
@@ -6,6 +6,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/rancher/octopus/adaptors/ble/pkg/ble"
+	"github.com/rancher/octopus/pkg/adaptor/log"
+	"github.com/rancher/octopus/pkg/util/log/logflag"
 	"github.com/rancher/octopus/pkg/util/version/verflag"
 )
 
@@ -20,10 +22,14 @@ func newCommand() *cobra.Command {
 		Long: description,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			verflag.PrintAndExitIfRequested(name)
+			logflag.SetLogger(log.SetLogger)
+
 			return ble.Run()
 		},
 	}
+
 	verflag.AddFlags(c.Flags())
+	logflag.AddFlags(c.Flags())
 	return c
 }
 

--- a/adaptors/ble/pkg/ble/ble.go
+++ b/adaptors/ble/pkg/ble/ble.go
@@ -1,13 +1,15 @@
 package ble
 
 import (
+	"golang.org/x/sync/errgroup"
+	ctrl "sigs.k8s.io/controller-runtime"
+
 	"github.com/rancher/octopus/adaptors/ble/pkg/adaptor"
 	api "github.com/rancher/octopus/pkg/adaptor/api/v1alpha1"
 	"github.com/rancher/octopus/pkg/adaptor/connection"
+	"github.com/rancher/octopus/pkg/adaptor/log"
 	"github.com/rancher/octopus/pkg/adaptor/registration"
 	"github.com/rancher/octopus/pkg/util/critical"
-	"golang.org/x/sync/errgroup"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 const (
@@ -20,6 +22,8 @@ const (
 // +kubebuilder:rbac:groups=devices.edge.cattle.io,resources=bluetoothdevices/status,verbs=get;update;patch
 
 func Run() error {
+	log.Info("Starting")
+
 	var stop = ctrl.SetupSignalHandler()
 	var ctx = critical.Context(stop)
 	eg, ctx := errgroup.WithContext(ctx)

--- a/adaptors/dummy/cmd/dummy/main.go
+++ b/adaptors/dummy/cmd/dummy/main.go
@@ -6,6 +6,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/rancher/octopus/adaptors/dummy/pkg/dummy"
+	"github.com/rancher/octopus/pkg/adaptor/log"
+	"github.com/rancher/octopus/pkg/util/log/logflag"
 	"github.com/rancher/octopus/pkg/util/version/verflag"
 )
 
@@ -20,11 +22,14 @@ func newCommand() *cobra.Command {
 		Long: description,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			verflag.PrintAndExitIfRequested(name)
+			logflag.SetLogger(log.SetLogger)
+
 			return dummy.Run()
 		},
 	}
 
 	verflag.AddFlags(c.Flags())
+	logflag.AddFlags(c.Flags())
 	return c
 }
 

--- a/adaptors/dummy/pkg/adaptor/service.go
+++ b/adaptors/dummy/pkg/adaptor/service.go
@@ -2,35 +2,20 @@ package adaptor
 
 import (
 	jsoniter "github.com/json-iterator/go"
-	uberzap "go.uber.org/zap"
-	uberzapcore "go.uber.org/zap/zapcore"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	logr "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/rancher/octopus/adaptors/dummy/api/v1alpha1"
 	"github.com/rancher/octopus/adaptors/dummy/pkg/physical"
 	api "github.com/rancher/octopus/pkg/adaptor/api/v1alpha1"
 	"github.com/rancher/octopus/pkg/adaptor/connection"
+	"github.com/rancher/octopus/pkg/adaptor/log"
 	"github.com/rancher/octopus/pkg/util/object"
 )
-
-var log = logr.NewDelegatingLogger(nil)
-
-func init() {
-	log.Fulfill(zap.New(
-		zap.UseDevMode(true),
-		zap.Level(func() *uberzap.AtomicLevel {
-			level := uberzap.NewAtomicLevelAt(uberzapcore.DebugLevel)
-			return &level
-		}()),
-	))
-}
 
 func NewService() *Service {
 	var scheme = k8sruntime.NewScheme()

--- a/adaptors/dummy/pkg/dummy/dummy.go
+++ b/adaptors/dummy/pkg/dummy/dummy.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rancher/octopus/adaptors/dummy/pkg/adaptor"
 	api "github.com/rancher/octopus/pkg/adaptor/api/v1alpha1"
 	"github.com/rancher/octopus/pkg/adaptor/connection"
+	"github.com/rancher/octopus/pkg/adaptor/log"
 	"github.com/rancher/octopus/pkg/adaptor/registration"
 	"github.com/rancher/octopus/pkg/util/critical"
 )
@@ -23,6 +24,8 @@ const (
 // +kubebuilder:rbac:groups=devices.edge.cattle.io,resources=dummyprotocoldevices/status,verbs=get;update;patch
 
 func Run() error {
+	log.Info("Starting")
+
 	var stop = ctrl.SetupSignalHandler()
 	var ctx = critical.Context(stop)
 	eg, ctx := errgroup.WithContext(ctx)

--- a/adaptors/modbus/cmd/modbus/main.go
+++ b/adaptors/modbus/cmd/modbus/main.go
@@ -6,6 +6,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/rancher/octopus/adaptors/modbus/pkg/modbus"
+	"github.com/rancher/octopus/pkg/adaptor/log"
+	"github.com/rancher/octopus/pkg/util/log/logflag"
 	"github.com/rancher/octopus/pkg/util/version/verflag"
 )
 
@@ -20,10 +22,14 @@ func newCommand() *cobra.Command {
 		Long: description,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			verflag.PrintAndExitIfRequested(name)
+			logflag.SetLogger(log.SetLogger)
+
 			return modbus.Run()
 		},
 	}
+
 	verflag.AddFlags(c.Flags())
+	logflag.AddFlags(c.Flags())
 	return c
 }
 

--- a/adaptors/modbus/pkg/adaptor/service.go
+++ b/adaptors/modbus/pkg/adaptor/service.go
@@ -2,8 +2,6 @@ package adaptor
 
 import (
 	jsoniter "github.com/json-iterator/go"
-	uberzap "go.uber.org/zap"
-	uberzapcore "go.uber.org/zap/zapcore"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -11,27 +9,14 @@ import (
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	logr "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/rancher/octopus/adaptors/modbus/api/v1alpha1"
 	"github.com/rancher/octopus/adaptors/modbus/pkg/physical"
 	api "github.com/rancher/octopus/pkg/adaptor/api/v1alpha1"
 	"github.com/rancher/octopus/pkg/adaptor/connection"
+	"github.com/rancher/octopus/pkg/adaptor/log"
 	"github.com/rancher/octopus/pkg/util/object"
 )
-
-var log = logr.NewDelegatingLogger(nil)
-
-func init() {
-	log.Fulfill(zap.New(
-		zap.UseDevMode(true),
-		zap.Level(func() *uberzap.AtomicLevel {
-			level := uberzap.NewAtomicLevelAt(uberzapcore.DebugLevel)
-			return &level
-		}()),
-	))
-}
 
 func NewService() *Service {
 	var scheme = k8sruntime.NewScheme()
@@ -93,6 +78,10 @@ func (s *Service) Connect(server api.Connection_ConnectServer) error {
 		// process device
 		if device == nil {
 			var deviceName = object.GetNamespacedName(&modbus)
+			if deviceName.Namespace == "" || deviceName.Name == "" {
+				return status.Error(codes.InvalidArgument, "failed to recognize the empty device as the namespace/name is blank")
+			}
+
 			var dataHandler = func(name types.NamespacedName, status v1alpha1.ModbusDeviceStatus) {
 				// send device by {name, namespace, status} tuple
 				var resp v1alpha1.ModbusDevice

--- a/adaptors/modbus/pkg/modbus/modbus.go
+++ b/adaptors/modbus/pkg/modbus/modbus.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rancher/octopus/adaptors/modbus/pkg/adaptor"
 	api "github.com/rancher/octopus/pkg/adaptor/api/v1alpha1"
 	"github.com/rancher/octopus/pkg/adaptor/connection"
+	"github.com/rancher/octopus/pkg/adaptor/log"
 	"github.com/rancher/octopus/pkg/adaptor/registration"
 	"github.com/rancher/octopus/pkg/util/critical"
 )
@@ -21,6 +22,8 @@ const (
 // +kubebuilder:rbac:groups=devices.edge.cattle.io,resources=modbusdevices/status,verbs=get;update;patch
 
 func Run() error {
+	log.Info("Starting")
+
 	var stop = ctrl.SetupSignalHandler()
 	var ctx = critical.Context(stop)
 	eg, ctx := errgroup.WithContext(ctx)

--- a/adaptors/mqtt/cmd/mqtt/main.go
+++ b/adaptors/mqtt/cmd/mqtt/main.go
@@ -6,6 +6,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/rancher/octopus/adaptors/mqtt/pkg/mqtt"
+	"github.com/rancher/octopus/pkg/adaptor/log"
+	"github.com/rancher/octopus/pkg/util/log/logflag"
 	"github.com/rancher/octopus/pkg/util/version/verflag"
 )
 
@@ -20,11 +22,14 @@ func newCommand() *cobra.Command {
 		Long: description,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			verflag.PrintAndExitIfRequested(name)
+			logflag.SetLogger(log.SetLogger)
+
 			return mqtt.Run()
 		},
 	}
 
 	verflag.AddFlags(c.Flags())
+	logflag.AddFlags(c.Flags())
 	return c
 }
 

--- a/adaptors/mqtt/pkg/adaptor/service.go
+++ b/adaptors/mqtt/pkg/adaptor/service.go
@@ -1,6 +1,7 @@
 package adaptor
 
 import (
+	jsoniter "github.com/json-iterator/go"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -8,21 +9,17 @@ import (
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	jsoniter "github.com/json-iterator/go"
 	"github.com/rancher/octopus/adaptors/mqtt/api/v1alpha1"
 	"github.com/rancher/octopus/adaptors/mqtt/pkg/physical"
 	api "github.com/rancher/octopus/pkg/adaptor/api/v1alpha1"
 	"github.com/rancher/octopus/pkg/adaptor/connection"
-	logr "sigs.k8s.io/controller-runtime/pkg/log"
+	"github.com/rancher/octopus/pkg/adaptor/log"
+	"github.com/rancher/octopus/pkg/util/object"
 )
-
-var log = logr.NewDelegatingLogger(zap.New(zap.UseDevMode(true)))
 
 func NewService() *Service {
 	var scheme = k8sruntime.NewScheme()
-	//
 	utilruntime.Must(v1alpha1.AddToScheme(scheme))
 
 	return &Service{
@@ -80,6 +77,11 @@ func (s *Service) Connect(server api.Connection_ConnectServer) error {
 		}
 
 		if device == nil {
+			var deviceName = object.GetNamespacedName(&mqtt)
+			if deviceName.Namespace == "" || deviceName.Name == "" {
+				return status.Error(codes.InvalidArgument, "failed to recognize the empty device as the namespace/name is blank")
+			}
+
 			var dataHandler = func(name types.NamespacedName, status v1alpha1.MqttDeviceStatus) {
 				// send device by {name, namespace, status} tuple
 				var resp v1alpha1.MqttDevice
@@ -107,7 +109,7 @@ func (s *Service) Connect(server api.Connection_ConnectServer) error {
 			}
 
 			device = physical.NewDevice(
-				log,
+				log.WithValues("device", deviceName),
 				&mqtt,
 				dataHandler,
 				mqttClient,

--- a/adaptors/mqtt/pkg/mqtt/mqtt.go
+++ b/adaptors/mqtt/pkg/mqtt/mqtt.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rancher/octopus/adaptors/mqtt/pkg/adaptor"
 	api "github.com/rancher/octopus/pkg/adaptor/api/v1alpha1"
 	"github.com/rancher/octopus/pkg/adaptor/connection"
+	"github.com/rancher/octopus/pkg/adaptor/log"
 	"github.com/rancher/octopus/pkg/adaptor/registration"
 	"github.com/rancher/octopus/pkg/util/critical"
 )
@@ -21,6 +22,8 @@ const (
 // +kubebuilder:rbac:groups=devices.edge.cattle.io,resources=mqttdevices/status,verbs=get;update;patch
 
 func Run() error {
+	log.Info("Starting")
+
 	var stop = ctrl.SetupSignalHandler()
 	var ctx = critical.Context(stop)
 	eg, ctx := errgroup.WithContext(ctx)

--- a/adaptors/opcua/cmd/opcua/main.go
+++ b/adaptors/opcua/cmd/opcua/main.go
@@ -3,9 +3,12 @@ package main
 import (
 	"os"
 
-	"github.com/rancher/octopus/adaptors/opcua/pkg/opcua"
-	"github.com/rancher/octopus/pkg/util/version/verflag"
 	"github.com/spf13/cobra"
+
+	"github.com/rancher/octopus/adaptors/opcua/pkg/opcua"
+	"github.com/rancher/octopus/pkg/adaptor/log"
+	"github.com/rancher/octopus/pkg/util/log/logflag"
+	"github.com/rancher/octopus/pkg/util/version/verflag"
 )
 
 const (
@@ -19,10 +22,14 @@ func newCommand() *cobra.Command {
 		Long: description,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			verflag.PrintAndExitIfRequested(name)
+			logflag.SetLogger(log.SetLogger)
+
 			return opcua.Run()
 		},
 	}
+
 	verflag.AddFlags(c.Flags())
+	logflag.AddFlags(c.Flags())
 	return c
 }
 

--- a/adaptors/opcua/pkg/adaptor/service.go
+++ b/adaptors/opcua/pkg/adaptor/service.go
@@ -2,8 +2,6 @@ package adaptor
 
 import (
 	jsoniter "github.com/json-iterator/go"
-	uberzap "go.uber.org/zap"
-	uberzapcore "go.uber.org/zap/zapcore"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -11,27 +9,14 @@ import (
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	logr "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/rancher/octopus/adaptors/opcua/api/v1alpha1"
 	"github.com/rancher/octopus/adaptors/opcua/pkg/physical"
 	api "github.com/rancher/octopus/pkg/adaptor/api/v1alpha1"
 	"github.com/rancher/octopus/pkg/adaptor/connection"
+	"github.com/rancher/octopus/pkg/adaptor/log"
 	"github.com/rancher/octopus/pkg/util/object"
 )
-
-var log = logr.NewDelegatingLogger(nil)
-
-func init() {
-	log.Fulfill(zap.New(
-		zap.UseDevMode(true),
-		zap.Level(func() *uberzap.AtomicLevel {
-			level := uberzap.NewAtomicLevelAt(uberzapcore.DebugLevel)
-			return &level
-		}()),
-	))
-}
 
 func NewService() *Service {
 	var scheme = k8sruntime.NewScheme()
@@ -93,6 +78,10 @@ func (s *Service) Connect(server api.Connection_ConnectServer) error {
 		// process device
 		if device == nil {
 			var deviceName = object.GetNamespacedName(&opcua)
+			if deviceName.Namespace == "" || deviceName.Name == "" {
+				return status.Error(codes.InvalidArgument, "failed to recognize the empty device as the namespace/name is blank")
+			}
+
 			var dataHandler = func(name types.NamespacedName, status v1alpha1.OPCUADeviceStatus) {
 				// send device by {name, namespace, status} tuple
 				var resp v1alpha1.OPCUADevice

--- a/adaptors/opcua/pkg/opcua/opcua.go
+++ b/adaptors/opcua/pkg/opcua/opcua.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rancher/octopus/adaptors/opcua/pkg/adaptor"
 	api "github.com/rancher/octopus/pkg/adaptor/api/v1alpha1"
 	"github.com/rancher/octopus/pkg/adaptor/connection"
+	"github.com/rancher/octopus/pkg/adaptor/log"
 	"github.com/rancher/octopus/pkg/adaptor/registration"
 	"github.com/rancher/octopus/pkg/util/critical"
 )
@@ -21,6 +22,8 @@ const (
 // +kubebuilder:rbac:groups=devices.edge.cattle.io,resources=opcuadevices/status,verbs=get;update;patch
 
 func Run() error {
+	log.Info("Starting")
+
 	var stop = ctrl.SetupSignalHandler()
 	var ctx = critical.Context(stop)
 	eg, ctx := errgroup.WithContext(ctx)

--- a/cmd/brain/brain.go
+++ b/cmd/brain/brain.go
@@ -3,6 +3,8 @@ package brain
 import (
 	"github.com/spf13/cobra"
 
+	ctrl "sigs.k8s.io/controller-runtime"
+
 	"github.com/rancher/octopus/cmd/brain/options"
 	"github.com/rancher/octopus/cmd/decorator"
 	"github.com/rancher/octopus/pkg/brain"
@@ -23,7 +25,7 @@ func NewCommand() *cobra.Command {
 		Long: description,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			verflag.PrintAndExitIfRequested(name)
-			logflag.Configure()
+			logflag.SetLogger(ctrl.SetLogger)
 
 			return brain.Run(name, opts)
 		},

--- a/cmd/limb/limb.go
+++ b/cmd/limb/limb.go
@@ -3,6 +3,8 @@ package limb
 import (
 	"github.com/spf13/cobra"
 
+	ctrl "sigs.k8s.io/controller-runtime"
+
 	"github.com/rancher/octopus/cmd/decorator"
 	"github.com/rancher/octopus/cmd/limb/options"
 	"github.com/rancher/octopus/pkg/limb"
@@ -23,7 +25,7 @@ func NewCommand() *cobra.Command {
 		Long: description,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			verflag.PrintAndExitIfRequested(name)
-			logflag.Configure()
+			logflag.SetLogger(ctrl.SetLogger)
 
 			return limb.Run(name, opts)
 		},

--- a/pkg/adaptor/log/log.go
+++ b/pkg/adaptor/log/log.go
@@ -1,0 +1,37 @@
+package log
+
+import (
+	"github.com/go-logr/logr"
+
+	"github.com/rancher/octopus/pkg/util/log/zap"
+)
+
+var log = zap.NewNullLogger()
+
+func SetLogger(logger logr.Logger) {
+	log = logger
+}
+
+func Info(msg string, keysAndValues ...interface{}) {
+	log.Info(msg, keysAndValues...)
+}
+
+func Enabled() bool {
+	return log.Enabled()
+}
+
+func Error(err error, msg string, keysAndValues ...interface{}) {
+	log.Error(err, msg, keysAndValues...)
+}
+
+func V(level int) logr.InfoLogger {
+	return log.V(level)
+}
+
+func WithValues(keysAndValues ...interface{}) logr.Logger {
+	return log.WithValues(keysAndValues...)
+}
+
+func WithName(name string) logr.Logger {
+	return log.WithName(name)
+}

--- a/pkg/util/log/logflag/logflag.go
+++ b/pkg/util/log/logflag/logflag.go
@@ -1,8 +1,8 @@
 package logflag
 
 import (
+	"github.com/go-logr/logr"
 	flag "github.com/spf13/pflag"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/rancher/octopus/pkg/util/log/zap"
 )
@@ -21,7 +21,11 @@ func AddFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&logging.inProduction, "log-in-production", logging.inProduction, "Use the reasonable production logging configuration of zap.")
 }
 
-func Configure() {
-	var logger = zap.NewLogger(logging.asJSON, logging.inProduction)
-	ctrl.SetLogger(zap.WrapAsLogr(logging.verbosity, logger))
+// LoggerSetter injects a function to set logger.
+type LoggerSetter func(logger logr.Logger)
+
+// SetLogger calls the setter to set the logr.logger.
+func SetLogger(setter LoggerSetter) {
+	var zapLogger = zap.NewLogger(logging.asJSON, logging.inProduction)
+	setter(zap.WrapAsLogrWithVerbosity(logging.verbosity, zapLogger))
 }

--- a/pkg/util/log/zap/logr_info_loggers.go
+++ b/pkg/util/log/zap/logr_info_loggers.go
@@ -1,0 +1,97 @@
+package zap
+
+import (
+	"github.com/go-logr/logr"
+	"go.uber.org/zap"
+)
+
+// nullInfoLogger doesn't log any log.
+type nullInfoLogger struct{}
+
+func (nullInfoLogger) Enabled() bool                   { return false }
+func (nullInfoLogger) Info(_ string, _ ...interface{}) {}
+
+// DebugInfoLogger logs as Debug level.
+type debugInfoLogger struct {
+	z *zap.Logger
+}
+
+func (l debugInfoLogger) Enabled() bool { return true }
+func (l debugInfoLogger) Info(msg string, keysAndValues ...interface{}) {
+	l.z.Debug(msg, handleFields(keysAndValues)...)
+}
+func (l debugInfoLogger) ToZapLogger() *zap.Logger { return l.z }
+
+// infoInfoLogger logs as Info level.
+type infoInfoLogger struct {
+	z *zap.Logger
+}
+
+func (l infoInfoLogger) Enabled() bool { return true }
+func (l infoInfoLogger) Info(msg string, keysAndValues ...interface{}) {
+	l.z.Info(msg, handleFields(keysAndValues)...)
+}
+func (l infoInfoLogger) ToZapLogger() *zap.Logger { return l.z }
+
+// warnInfoLogger logs as Warn level.
+type warnInfoLogger struct {
+	z *zap.Logger
+}
+
+func (l warnInfoLogger) Enabled() bool { return true }
+func (l warnInfoLogger) Info(msg string, keysAndValues ...interface{}) {
+	l.z.Warn(msg, handleFields(keysAndValues)...)
+}
+func (l warnInfoLogger) ToZapLogger() *zap.Logger { return l.z }
+
+// errorInfoLogger logs as Error level.
+type errorInfoLogger struct {
+	z *zap.Logger
+}
+
+func (l errorInfoLogger) Enabled() bool { return true }
+func (l errorInfoLogger) Info(msg string, keysAndValues ...interface{}) {
+	l.z.Error(msg, handleFields(keysAndValues)...)
+}
+func (l errorInfoLogger) ToZapLogger() *zap.Logger { return l.z }
+
+// fatalInfoLogger logs as Fatal level.
+type fatalInfoLogger struct {
+	z *zap.Logger
+}
+
+func (l fatalInfoLogger) Enabled() bool { return true }
+func (l fatalInfoLogger) Info(msg string, keysAndValues ...interface{}) {
+	l.z.Fatal(msg, handleFields(keysAndValues)...)
+}
+func (l fatalInfoLogger) ToZapLogger() *zap.Logger { return l.z }
+
+// NewNullInfoLogr returns a null logr.InfoLogger.
+func NewNullInfoLogr() logr.InfoLogger {
+	return nullInfoLogger{}
+}
+
+// WrapAsDebugInfoLogr wraps a Zap logger as a logr.InfoLogger to logs in Debug level.
+func WrapAsDebugInfoLogr(z *zap.Logger) logr.InfoLogger {
+	return debugInfoLogger{z: z}
+}
+
+// WrapAsInfoInfoLogr wraps a Zap logger as a logr.InfoLogger to logs in Info level.
+func WrapAsInfoInfoLogr(z *zap.Logger) logr.InfoLogger {
+	return infoInfoLogger{z: z}
+}
+
+// WrapAsWarnInfoLogr wraps a Zap logger as a logr.InfoLogger to logs in Warn level.
+func WrapAsWarnInfoLogr(z *zap.Logger) logr.InfoLogger {
+	return warnInfoLogger{z: z}
+}
+
+// WrapAsErrorInfoLogr wraps a Zap logger as a logr.InfoLogger to logs in Error level.
+func WrapAsErrorInfoLogr(z *zap.Logger) logr.InfoLogger {
+	return errorInfoLogger{z: z}
+}
+
+// WrapAsFatalInfoLogr wraps a Zap logger as a logr.InfoLogger to logs in Fatal level.
+func WrapAsFatalInfoLogr(z *zap.Logger) logr.InfoLogger {
+	return fatalInfoLogger{z: z}
+}

--- a/pkg/util/log/zap/zap.go
+++ b/pkg/util/log/zap/zap.go
@@ -8,8 +8,13 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+type LoggerWrapper interface {
+	ToZapLogger() *zap.Logger
+}
+
+// NewLogger creates a Zap logger.
 func NewLogger(asJSON, inProduction bool) *zap.Logger {
-	var zapLevel = zap.InfoLevel
+	var zapLevel = zap.DebugLevel
 	var zapWriteSyncer = zapcore.AddSync(os.Stderr)
 	var zapOptions = []zap.Option{
 		zap.AddCallerSkip(1),
@@ -19,6 +24,7 @@ func NewLogger(asJSON, inProduction bool) *zap.Logger {
 
 	var zapEncoderConfig = zap.NewDevelopmentEncoderConfig()
 	if inProduction {
+		zapLevel = zap.InfoLevel
 		zapEncoderConfig = zap.NewProductionEncoderConfig()
 		zapOptions = append(zapOptions,
 			zap.WrapCore(func(core zapcore.Core) zapcore.Core {
@@ -33,4 +39,9 @@ func NewLogger(asJSON, inProduction bool) *zap.Logger {
 	}
 
 	return zap.New(zapcore.NewCore(zapEncoder, zapWriteSyncer, zapLevel), zapOptions...)
+}
+
+// NewDevelopmentLogger creates a Zap logger with development configuration.
+func NewDevelopmentLogger() *zap.Logger {
+	return NewLogger(false, false)
 }

--- a/template/adaptor/cmd/template/main.go
+++ b/template/adaptor/cmd/template/main.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/rancher/octopus/pkg/adaptor/log"
+	"github.com/rancher/octopus/pkg/util/log/logflag"
 	"github.com/rancher/octopus/pkg/util/version/verflag"
 	"github.com/rancher/octopus/template/adaptor/pkg/template"
 )
@@ -20,11 +22,14 @@ func newCommand() *cobra.Command {
 		Long: description,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			verflag.PrintAndExitIfRequested(name)
+			logflag.SetLogger(log.SetLogger)
+
 			return template.Run()
 		},
 	}
 
 	verflag.AddFlags(c.Flags())
+	logflag.AddFlags(c.Flags())
 	return c
 }
 

--- a/template/adaptor/pkg/adaptor/service.go
+++ b/template/adaptor/pkg/adaptor/service.go
@@ -1,30 +1,14 @@
 package adaptor
 
 import (
-	uberzap "go.uber.org/zap"
-	uberzapcore "go.uber.org/zap/zapcore"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	logr "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	api "github.com/rancher/octopus/pkg/adaptor/api/v1alpha1"
 	"github.com/rancher/octopus/template/adaptor/api/v1alpha1"
 )
-
-var log = logr.NewDelegatingLogger(nil)
-
-func init() {
-	log.Fulfill(zap.New(
-		zap.UseDevMode(true),
-		zap.Level(func() *uberzap.AtomicLevel {
-			level := uberzap.NewAtomicLevelAt(uberzapcore.DebugLevel)
-			return &level
-		}()),
-	))
-}
 
 func NewService() *Service {
 	var scheme = k8sruntime.NewScheme()

--- a/template/adaptor/pkg/template/template.go
+++ b/template/adaptor/pkg/template/template.go
@@ -6,6 +6,7 @@ import (
 
 	api "github.com/rancher/octopus/pkg/adaptor/api/v1alpha1"
 	"github.com/rancher/octopus/pkg/adaptor/connection"
+	"github.com/rancher/octopus/pkg/adaptor/log"
 	"github.com/rancher/octopus/pkg/adaptor/registration"
 	"github.com/rancher/octopus/pkg/util/critical"
 	"github.com/rancher/octopus/template/adaptor/pkg/adaptor"
@@ -21,6 +22,8 @@ const (
 // +kubebuilder:rbac:groups=devices.edge.cattle.io,resources=templatedevices/status,verbs=get;update;patch
 
 func Run() error {
+	log.Info("Starting")
+
 	var stop = ctrl.SetupSignalHandler()
 	var ctx = critical.Context(stop)
 	eg, ctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
<!-- [1] Please search for existing PR first, the duplicate PR may not be received.
If the PR has the same fix/enhancement as other, please related them together and explain in step [5].
-->

<!-- [2] Please do not create a PR without creating an issue first.
List issues to be fixed.
-->
**Fixes:**

#94

<!-- [3] Describe what the PR fixes or enhances. -->
**Problem:**

It's better to parameterize the log of all adaptors.

<!-- [4] Describe what the PR does. -->
**Solution:**

- add a parameter entrance of all adaptors
- adjust the log parameter entrance of `brain` and `limb`
- implement a log util

<!-- [5] Describe the plan for regression testing, if no, just write "None" in here.-->
**Test plan:**

> This modification has provided the new package `github.com/rancher/octopus/pkg/adaptor/log` to use logging, you can use the `log` package instead of a logr instance in the adaptor. cc @shanewxy , @parchk , @guangbochen 

None