### PR TITLE
ci: support multiple actions in build process management

### DIFF
--- a/adaptors/ble/hack/make-rules/adaptor.sh
+++ b/adaptors/ble/hack/make-rules/adaptor.sh
@@ -282,23 +282,30 @@ function entry() {
   local adaptor="${1:-}"
   shift 1
 
-  local stage="${1:-build}"
+  local stages="${1:-build}"
   shift $(($# > 0 ? 1 : 0))
 
-  octopus::log::info "make adaptor ${adaptor} ${stage} $*"
+  IFS="," read -r -a stages <<<"${stages}"
+  local commands=$*
+  if [[ ${#stages[@]} -ne 1 ]]; then
+    commands="only"
+  fi
 
-  case ${stage} in
-  g | gen | generate) generate "${adaptor}" "$@" ;;
-  m | mod) mod "${adaptor}" "$@" ;;
-  l | lint) lint "${adaptor}" "$@" ;;
-  b | build) build "${adaptor}" "$@" ;;
-  p | pkg | package) package "${adaptor}" "$@" ;;
-  d | dep | deploy) deploy "${adaptor}" "$@" ;;
-  t | test) test "${adaptor}" "$@" ;;
-  v | ver | verify) verify "${adaptor}" "$@" ;;
-  e | e2e) e2e "${adaptor}" "$@" ;;
-  *) octopus::log::fatal "unknown action '${stage}', select from generate,mod,lint,build,test,verify,package,deploy,e2e" ;;
-  esac
+  for stage in "${stages[@]}"; do
+    octopus::log::info "# make adaptor ${adaptor} ${stage} ${commands}"
+    case ${stage} in
+    g | gen | generate) generate "${adaptor}" "${commands}" ;;
+    m | mod) mod "${adaptor}" "${commands}" ;;
+    l | lint) lint "${adaptor}" "${commands}" ;;
+    b | build) build "${adaptor}" "${commands}" ;;
+    p | pkg | package) package "${adaptor}" "${commands}" ;;
+    d | dep | deploy) deploy "${adaptor}" "${commands}" ;;
+    t | test) test "${adaptor}" "${commands}" ;;
+    v | ver | verify) verify "${adaptor}" "${commands}" ;;
+    e | e2e) e2e "${adaptor}" "${commands}" ;;
+    *) octopus::log::fatal "unknown action '${stage}', select from generate,mod,lint,build,test,verify,package,deploy,e2e" ;;
+    esac
+  done
 }
 
 if [[ ${BY:-} == "dapper" ]]; then

--- a/adaptors/dummy/hack/make-rules/adaptor.sh
+++ b/adaptors/dummy/hack/make-rules/adaptor.sh
@@ -285,23 +285,30 @@ function entry() {
   local adaptor="${1:-}"
   shift 1
 
-  local stage="${1:-build}"
+  local stages="${1:-build}"
   shift $(($# > 0 ? 1 : 0))
 
-  octopus::log::info "make adaptor ${adaptor} ${stage} $*"
+  IFS="," read -r -a stages <<<"${stages}"
+  local commands=$*
+  if [[ ${#stages[@]} -ne 1 ]]; then
+    commands="only"
+  fi
 
-  case ${stage} in
-  g | gen | generate) generate "${adaptor}" "$@" ;;
-  m | mod) mod "${adaptor}" "$@" ;;
-  l | lint) lint "${adaptor}" "$@" ;;
-  b | build) build "${adaptor}" "$@" ;;
-  p | pkg | package) package "${adaptor}" "$@" ;;
-  d | dep | deploy) deploy "${adaptor}" "$@" ;;
-  t | test) test "${adaptor}" "$@" ;;
-  v | ver | verify) verify "${adaptor}" "$@" ;;
-  e | e2e) e2e "${adaptor}" "$@" ;;
-  *) octopus::log::fatal "unknown action '${stage}', select from generate,mod,lint,build,test,verify,package,deploy,e2e" ;;
-  esac
+  for stage in "${stages[@]}"; do
+    octopus::log::info "# make adaptor ${adaptor} ${stage} ${commands}"
+    case ${stage} in
+    g | gen | generate) generate "${adaptor}" "${commands}" ;;
+    m | mod) mod "${adaptor}" "${commands}" ;;
+    l | lint) lint "${adaptor}" "${commands}" ;;
+    b | build) build "${adaptor}" "${commands}" ;;
+    p | pkg | package) package "${adaptor}" "${commands}" ;;
+    d | dep | deploy) deploy "${adaptor}" "${commands}" ;;
+    t | test) test "${adaptor}" "${commands}" ;;
+    v | ver | verify) verify "${adaptor}" "${commands}" ;;
+    e | e2e) e2e "${adaptor}" "${commands}" ;;
+    *) octopus::log::fatal "unknown action '${stage}', select from generate,mod,lint,build,test,verify,package,deploy,e2e" ;;
+    esac
+  done
 }
 
 if [[ ${BY:-} == "dapper" ]]; then

--- a/adaptors/modbus/hack/make-rules/adaptor.sh
+++ b/adaptors/modbus/hack/make-rules/adaptor.sh
@@ -282,23 +282,30 @@ function entry() {
   local adaptor="${1:-}"
   shift 1
 
-  local stage="${1:-build}"
+  local stages="${1:-build}"
   shift $(($# > 0 ? 1 : 0))
 
-  octopus::log::info "make adaptor ${adaptor} ${stage} $*"
+  IFS="," read -r -a stages <<<"${stages}"
+  local commands=$*
+  if [[ ${#stages[@]} -ne 1 ]]; then
+    commands="only"
+  fi
 
-  case ${stage} in
-  g | gen | generate) generate "${adaptor}" "$@" ;;
-  m | mod) mod "${adaptor}" "$@" ;;
-  l | lint) lint "${adaptor}" "$@" ;;
-  b | build) build "${adaptor}" "$@" ;;
-  p | pkg | package) package "${adaptor}" "$@" ;;
-  d | dep | deploy) deploy "${adaptor}" "$@" ;;
-  t | test) test "${adaptor}" "$@" ;;
-  v | ver | verify) verify "${adaptor}" "$@" ;;
-  e | e2e) e2e "${adaptor}" "$@" ;;
-  *) octopus::log::fatal "unknown action '${stage}', select from generate,mod,lint,build,test,verify,package,deploy,e2e" ;;
-  esac
+  for stage in "${stages[@]}"; do
+    octopus::log::info "# make adaptor ${adaptor} ${stage} ${commands}"
+    case ${stage} in
+    g | gen | generate) generate "${adaptor}" "${commands}" ;;
+    m | mod) mod "${adaptor}" "${commands}" ;;
+    l | lint) lint "${adaptor}" "${commands}" ;;
+    b | build) build "${adaptor}" "${commands}" ;;
+    p | pkg | package) package "${adaptor}" "${commands}" ;;
+    d | dep | deploy) deploy "${adaptor}" "${commands}" ;;
+    t | test) test "${adaptor}" "${commands}" ;;
+    v | ver | verify) verify "${adaptor}" "${commands}" ;;
+    e | e2e) e2e "${adaptor}" "${commands}" ;;
+    *) octopus::log::fatal "unknown action '${stage}', select from generate,mod,lint,build,test,verify,package,deploy,e2e" ;;
+    esac
+  done
 }
 
 if [[ ${BY:-} == "dapper" ]]; then

--- a/adaptors/mqtt/hack/make-rules/adaptor.sh
+++ b/adaptors/mqtt/hack/make-rules/adaptor.sh
@@ -290,23 +290,30 @@ function entry() {
   local adaptor="${1:-}"
   shift 1
 
-  local stage="${1:-build}"
+  local stages="${1:-build}"
   shift $(($# > 0 ? 1 : 0))
 
-  octopus::log::info "make adaptor ${adaptor} ${stage} $*"
+  IFS="," read -r -a stages <<<"${stages}"
+  local commands=$*
+  if [[ ${#stages[@]} -ne 1 ]]; then
+    commands="only"
+  fi
 
-  case ${stage} in
-  g | gen | generate) generate "${adaptor}" "$@" ;;
-  m | mod) mod "${adaptor}" "$@" ;;
-  l | lint) lint "${adaptor}" "$@" ;;
-  b | build) build "${adaptor}" "$@" ;;
-  p | pkg | package) package "${adaptor}" "$@" ;;
-  d | dep | deploy) deploy "${adaptor}" "$@" ;;
-  t | test) test "${adaptor}" "$@" ;;
-  v | ver | verify) verify "${adaptor}" "$@" ;;
-  e | e2e) e2e "${adaptor}" "$@" ;;
-  *) octopus::log::fatal "unknown action '${stage}', select from generate,mod,lint,build,test,verify,package,deploy,e2e" ;;
-  esac
+  for stage in "${stages[@]}"; do
+    octopus::log::info "# make adaptor ${adaptor} ${stage} ${commands}"
+    case ${stage} in
+    g | gen | generate) generate "${adaptor}" "${commands}" ;;
+    m | mod) mod "${adaptor}" "${commands}" ;;
+    l | lint) lint "${adaptor}" "${commands}" ;;
+    b | build) build "${adaptor}" "${commands}" ;;
+    p | pkg | package) package "${adaptor}" "${commands}" ;;
+    d | dep | deploy) deploy "${adaptor}" "${commands}" ;;
+    t | test) test "${adaptor}" "${commands}" ;;
+    v | ver | verify) verify "${adaptor}" "${commands}" ;;
+    e | e2e) e2e "${adaptor}" "${commands}" ;;
+    *) octopus::log::fatal "unknown action '${stage}', select from generate,mod,lint,build,test,verify,package,deploy,e2e" ;;
+    esac
+  done
 }
 
 if [[ ${BY:-} == "dapper" ]]; then

--- a/adaptors/opcua/hack/make-rules/adaptor.sh
+++ b/adaptors/opcua/hack/make-rules/adaptor.sh
@@ -282,23 +282,30 @@ function entry() {
   local adaptor="${1:-}"
   shift 1
 
-  local stage="${1:-build}"
+  local stages="${1:-build}"
   shift $(($# > 0 ? 1 : 0))
 
-  octopus::log::info "make adaptor ${adaptor} ${stage} $*"
+  IFS="," read -r -a stages <<<"${stages}"
+  local commands=$*
+  if [[ ${#stages[@]} -ne 1 ]]; then
+    commands="only"
+  fi
 
-  case ${stage} in
-  g | gen | generate) generate "${adaptor}" "$@" ;;
-  m | mod) mod "${adaptor}" "$@" ;;
-  l | lint) lint "${adaptor}" "$@" ;;
-  b | build) build "${adaptor}" "$@" ;;
-  p | pkg | package) package "${adaptor}" "$@" ;;
-  d | dep | deploy) deploy "${adaptor}" "$@" ;;
-  t | test) test "${adaptor}" "$@" ;;
-  v | ver | verify) verify "${adaptor}" "$@" ;;
-  e | e2e) e2e "${adaptor}" "$@" ;;
-  *) octopus::log::fatal "unknown action '${stage}', select from generate,mod,lint,build,test,verify,package,deploy,e2e" ;;
-  esac
+  for stage in "${stages[@]}"; do
+    octopus::log::info "# make adaptor ${adaptor} ${stage} ${commands}"
+    case ${stage} in
+    g | gen | generate) generate "${adaptor}" "${commands}" ;;
+    m | mod) mod "${adaptor}" "${commands}" ;;
+    l | lint) lint "${adaptor}" "${commands}" ;;
+    b | build) build "${adaptor}" "${commands}" ;;
+    p | pkg | package) package "${adaptor}" "${commands}" ;;
+    d | dep | deploy) deploy "${adaptor}" "${commands}" ;;
+    t | test) test "${adaptor}" "${commands}" ;;
+    v | ver | verify) verify "${adaptor}" "${commands}" ;;
+    e | e2e) e2e "${adaptor}" "${commands}" ;;
+    *) octopus::log::fatal "unknown action '${stage}', select from generate,mod,lint,build,test,verify,package,deploy,e2e" ;;
+    esac
+  done
 }
 
 if [[ ${BY:-} == "dapper" ]]; then

--- a/docs/octopus/develop.md
+++ b/docs/octopus/develop.md
@@ -21,19 +21,21 @@ Explanation of each action:
 
 | Action | Usage |
 |---:|:---|
-| `generate` | Generate deployment manifests and deepcopy/runtime.Object implementations of `octopus` via [`controller-gen`](https://github.com/kubernetes-sigs/controller-tools/blob/master/cmd/controller-gen/main.go); Generate proto files of `adaptor` interfaces via [`protoc`](https://github.com/protocolbuffers/protobuf). |
-| `mod` | Download `octopus` dependencies. |
-| `lint` | Verify `octopus` via [`golangci-lint`](https://github.com/golangci/golangci-lint), roll back to `go fmt` and `go vet` if the installation fails. |
-| `build` | Compile `octopus` according to the type and architecture of the OS, generate the binary into `bin` directory. <br/><br/> Use `CROSS=true` to compile binaries of the supported platforms(search `constant.sh` file in this repo). |
-| `test` | Run unit tests. |
-| `verify` | Run integration tests with a Kubernetes cluster. <br/><br/> Use `LOCAL_CLUSTER_KIND` to specify the type for local cluster, default is `k3d`. Instead of setting up a local cluster, you can also use environment variable `USE_EXISTING_CLUSTER=true` to point out an existing cluster, and then the integration tests will use the kubeconfig of the current environment to communicate with the existing cluster. |
-| `package` | Package Docker image. |
-| `e2e` | Run E2E tests. |
-| `deploy` | Push Docker images and create manifest images for the current version. <br/><br/> Use `WITHOUT_MANIFEST=true` to prevent pushing manifest image, or `ONLY_MANIFEST=true` to push the manifest images only and `IGNORE_MISSING=true` to warn on missing images defined in platform list if needed. |
+| `generate`, `gen`, `g` | Generate deployment manifests and deepcopy/runtime.Object implementations of `octopus` via [`controller-gen`](https://github.com/kubernetes-sigs/controller-tools/blob/master/cmd/controller-gen/main.go); Generate proto files of `adaptor` interfaces via [`protoc`](https://github.com/protocolbuffers/protobuf). |
+| `mod`, `m` | Download `octopus` dependencies. |
+| `lint`, `l` | Verify `octopus` via [`golangci-lint`](https://github.com/golangci/golangci-lint), roll back to `go fmt` and `go vet` if the installation fails. |
+| `build`, `b` | Compile `octopus` according to the type and architecture of the OS, generate the binary into `bin` directory. <br/><br/> Use `CROSS=true` to compile binaries of the supported platforms(search `constant.sh` file in this repo). |
+| `test`, `t` | Run unit tests. |
+| `verify`, `v` | Run integration tests with a Kubernetes cluster. <br/><br/> Use `LOCAL_CLUSTER_KIND` to specify the type for local cluster, default is `k3d`. Instead of setting up a local cluster, you can also use environment variable `USE_EXISTING_CLUSTER=true` to point out an existing cluster, and then the integration tests will use the kubeconfig of the current environment to communicate with the existing cluster. |
+| `package`, `pkg`, `p` | Package Docker image. |
+| `e2e`, `e` | Run E2E tests. |
+| `deploy`, `dep`, `d` | Push Docker images and create manifest images for the current version. <br/><br/> Use `WITHOUT_MANIFEST=true` to prevent pushing manifest image, or `ONLY_MANIFEST=true` to push the manifest images only and `IGNORE_MISSING=true` to warn on missing images defined in platform list if needed. |
 
 Executing a stage can run `make octopus <stage name>`, for example, when executing the `test` stage, please run `make octopus test`. To execute a stage will execute all actions in the previous sequence, if running `make octopus test`, it actually includes executing `generate`, `mod`, `lint`, `build` and `test` actions.
 
 To run an action by adding `only` command, for example, if only run `build` action, please use `make octopus build only`.
+
+To combine multiple actions can use a comma list, for example, if want to run `build`, `package` and `deploy` actions orderly, please use `make octopus build,package,deploy`.
 
 Integrate with [`dapper`](https://github.com/rancher/dapper) via `BY` environment variable, for example, if only run `build` action via [`dapper`](https://github.com/rancher/dapper), please use `BY=dapper make octopus build only`. 
 

--- a/hack/make-rules/octopus.sh
+++ b/hack/make-rules/octopus.sh
@@ -313,23 +313,30 @@ function e2e() {
 }
 
 function entry() {
-  local stage="${1:-build}"
+  local stages="${1:-build}"
   shift $(($# > 0 ? 1 : 0))
 
-  octopus::log::info "make octopus ${stage} $*"
+  IFS="," read -r -a stages <<<"${stages}"
+  local commands=$*
+  if [[ ${#stages[@]} -ne 1 ]]; then
+    commands="only"
+  fi
 
-  case ${stage} in
-  g | gen | generate) generate ;;
-  m | mod) mod "$@" ;;
-  l | lint) lint "$@" ;;
-  b | build) build "$@" ;;
-  p | pkg | package) package "$@" ;;
-  d | dep | deploy) deploy "$@" ;;
-  t | test) test "$@" ;;
-  v | ver | verify) verify "$@" ;;
-  e | e2e) e2e "$@" ;;
-  *) octopus::log::fatal "unknown action '${stage}', select from generate,mod,lint,build,test,verify,package,deploy,e2e" ;;
-  esac
+  for stage in "${stages[@]}"; do
+    octopus::log::info "# make octopus ${stage} ${commands}"
+    case ${stage} in
+    g | gen | generate) generate "${commands}" ;;
+    m | mod) mod "${commands}" ;;
+    l | lint) lint "${commands}" ;;
+    b | build) build "${commands}" ;;
+    p | pkg | package) package "${commands}" ;;
+    d | dep | deploy) deploy "${commands}" ;;
+    t | test) test "${commands}" ;;
+    v | ver | verify) verify "${commands}" ;;
+    e | e2e) e2e "${commands}" ;;
+    *) octopus::log::fatal "unknown action '${stage}', select from generate,mod,lint,build,test,verify,package,deploy,e2e" ;;
+    esac
+  done
 }
 
 if [[ ${BY:-} == "dapper" ]]; then

--- a/template/adaptor/hack/make-rules/adaptor.sh
+++ b/template/adaptor/hack/make-rules/adaptor.sh
@@ -290,23 +290,30 @@ function entry() {
   local adaptor="${1:-}"
   shift 1
 
-  local stage="${1:-build}"
+  local stages="${1:-build}"
   shift $(($# > 0 ? 1 : 0))
 
-  octopus::log::info "make adaptor ${adaptor} ${stage} $*"
+  IFS="," read -r -a stages <<<"${stages}"
+  local commands=$*
+  if [[ ${#stages[@]} -ne 1 ]]; then
+    commands="only"
+  fi
 
-  case ${stage} in
-  g | gen | generate) generate "${adaptor}" "$@" ;;
-  m | mod) mod "${adaptor}" "$@" ;;
-  l | lint) lint "${adaptor}" "$@" ;;
-  b | build) build "${adaptor}" "$@" ;;
-  p | pkg | package) package "${adaptor}" "$@" ;;
-  d | dep | deploy) deploy "${adaptor}" "$@" ;;
-  t | test) test "${adaptor}" "$@" ;;
-  v | ver | verify) verify "${adaptor}" "$@" ;;
-  e | e2e) e2e "${adaptor}" "$@" ;;
-  *) octopus::log::fatal "unknown action '${stage}', select from generate,mod,lint,build,test,verify,package,deploy,e2e" ;;
-  esac
+  for stage in "${stages[@]}"; do
+    octopus::log::info "# make adaptor ${adaptor} ${stage} ${commands}"
+    case ${stage} in
+    g | gen | generate) generate "${adaptor}" "${commands}" ;;
+    m | mod) mod "${adaptor}" "${commands}" ;;
+    l | lint) lint "${adaptor}" "${commands}" ;;
+    b | build) build "${adaptor}" "${commands}" ;;
+    p | pkg | package) package "${adaptor}" "${commands}" ;;
+    d | dep | deploy) deploy "${adaptor}" "${commands}" ;;
+    t | test) test "${adaptor}" "${commands}" ;;
+    v | ver | verify) verify "${adaptor}" "${commands}" ;;
+    e | e2e) e2e "${adaptor}" "${commands}" ;;
+    *) octopus::log::fatal "unknown action '${stage}', select from generate,mod,lint,build,test,verify,package,deploy,e2e" ;;
+    esac
+  done
 }
 
 if [[ ${BY:-} == "dapper" ]]; then


### PR DESCRIPTION
<!-- [1] Please search for existing PR first, the duplicate PR may not be received.
If the PR has the same fix/enhancement as other, please related them together and explain in step [5].
-->

<!-- [2] Please do not create a PR without creating an issue first.
List issues to be fixed.
-->
**Fixes:**

#96 

<!-- [3] Describe what the PR fixes or enhances. -->
**Problem:**

It's better to support multiple actions in build process management because the combination action is very helpful for testing or rapid development.

<!-- [4] Describe what the PR does. -->
**Solution:**

Recognize the comma-list action during the building, for example, `make octopus build,package,deploy` is to run `build`, `package`, `deploy` actions orderly.

<!-- [5] Describe the plan for regression testing, if no, just write "None" in here.-->
**Test plan:**

> This modification can support the multiple actions on `make octopus/adaptor` something. cc @DoNotSayYes , @guangbochen , @shanewxy , @parchk 

None
