### PR TITLE
fix: devicelink status is "healthy" when trying to connect to device

### DIFF
--- a/pkg/limb/controller/devicelink.go
+++ b/pkg/limb/controller/devicelink.go
@@ -323,7 +323,7 @@ func (r *DeviceLinkReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 			return ctrl.Result{}, nil
 		}
 
-		devicelink.SuccessOnDeviceConnected(&link.Status)
+		devicelink.WaitForDeviceConnected(&link.Status)
 		link.Status.DeviceTemplateGeneration = link.Generation
 		if err := r.Status().Update(ctx, &link); err != nil {
 			log.Error(err, "Unable to change the status of DeviceLink")

--- a/pkg/limb/controller/devicelink_connection.go
+++ b/pkg/limb/controller/devicelink_connection.go
@@ -90,6 +90,14 @@ func (r *DeviceLinkReconciler) ReceiveConnectionStatus(req suctioncup.RequestCon
 		return suctioncup.Response{}, nil
 	}
 
+	devicelink.SuccessOnDeviceConnected(&link.Status)
+	link.Status.DeviceTemplateGeneration = link.Generation
+	if err := r.Status().Update(ctx, &link); err != nil {
+		log.Error(err, "Unable to change the status of DeviceLink")
+		return suctioncup.Response{Requeue: true}, nil
+	}
+	r.Eventf(&link, "Normal", "Connected", "connected to device")
+
 	// updates device status
 	var updatedStatus interface{}
 	if err := func() error {

--- a/pkg/status/devicelink/condition.go
+++ b/pkg/status/devicelink/condition.go
@@ -103,6 +103,11 @@ func SuccessOnDeviceConnected(status *edgev1alpha1.DeviceLinkStatus) {
 		did(edgev1alpha1.DeviceLinkDeviceConnected, metav1.ConditionTrue, "Healthy", "")
 }
 
+func WaitForDeviceConnected(status *edgev1alpha1.DeviceLinkStatus) {
+	status.Conditions = deviceLinkConditions(status.Conditions).
+		did(edgev1alpha1.DeviceLinkDeviceConnected, metav1.ConditionTrue, "Waiting", "")
+}
+
 func ToCheckDeviceConnected(status *edgev1alpha1.DeviceLinkStatus) {
 	status.Conditions = deviceLinkConditions(status.Conditions).
 		did(edgev1alpha1.DeviceLinkDeviceConnected, metav1.ConditionUnknown, "Connecting", "connect device")


### PR DESCRIPTION

<!-- [1] Please search for existing PR first, the duplicate PR may not be received.
If the PR has the same fix/enhancement as other, please related them together and explain in step [5].
-->

<!-- [2] Please do not create a PR without creating an issue first.
List issues to be fixed.
-->
**Fixes:**
https://github.com/cnrancher/octopus/issues/102

<!-- [3] Describe what the PR fixes or enhances. -->
**Problem:**
The `devicelink` status was in `healthy` status when is not confirmed to be connecting to the device successfully in the beginning. If the endpoint of the device is invalid, it remains `healthy` and only changed to `unhealthy` after time out.

<!-- [4] Describe what the PR does. -->
**Solution:**
Another status `waiting` is used when the adaptor is attempting to connect to the device. 

<!-- [5] Describe the plan for regression testing, if no, just write "None" in here.-->
**Test plan:**
1. Start a cluster and deploy octopus
2. Deploy the adaptor, use Modbus adaptor as an example
3. Deploy a Modbus `devicelink` with an invalid server URL
4. Check the status change of it. Should change from `waiting` to `unhealthy`
