### PR TITLE
Set adaptors default image pull policy

### DIFF
--- a/adaptors/ble/deploy/e2e/all_in_one.yaml
+++ b/adaptors/ble/deploy/e2e/all_in_one.yaml
@@ -727,6 +727,7 @@ spec:
     spec:
       containers:
       - image: cnrancher/octopus-adaptor-ble:master
+        imagePullPolicy: Always
         name: octopus
         securityContext:
           privileged: true

--- a/adaptors/ble/deploy/manifests/workload/daemonset.yaml
+++ b/adaptors/ble/deploy/manifests/workload/daemonset.yaml
@@ -19,6 +19,7 @@ spec:
       containers:
         - name: octopus
           image: cnrancher/octopus-adaptor-ble:master
+          imagePullPolicy: Always
           securityContext:
             privileged: true
           volumeMounts:

--- a/adaptors/dummy/deploy/e2e/all_in_one.yaml
+++ b/adaptors/dummy/deploy/e2e/all_in_one.yaml
@@ -1329,6 +1329,7 @@ spec:
     spec:
       containers:
       - image: cnrancher/octopus-adaptor-dummy:master
+        imagePullPolicy: Always
         name: octopus
         volumeMounts:
         - mountPath: /var/lib/octopus/adaptors/

--- a/adaptors/dummy/deploy/manifests/workload/daemonset.yaml
+++ b/adaptors/dummy/deploy/manifests/workload/daemonset.yaml
@@ -19,6 +19,7 @@ spec:
       containers:
         - name: octopus
           image: cnrancher/octopus-adaptor-dummy:master
+          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /var/lib/octopus/adaptors/
               name: sockets

--- a/adaptors/modbus/deploy/e2e/all_in_one.yaml
+++ b/adaptors/modbus/deploy/e2e/all_in_one.yaml
@@ -788,6 +788,7 @@ spec:
     spec:
       containers:
       - image: cnrancher/octopus-adaptor-modbus:master
+        imagePullPolicy: Always
         name: octopus
         securityContext:
           privileged: true

--- a/adaptors/modbus/deploy/manifests/workload/daemonset.yaml
+++ b/adaptors/modbus/deploy/manifests/workload/daemonset.yaml
@@ -19,6 +19,7 @@ spec:
       containers:
         - name: octopus
           image: cnrancher/octopus-adaptor-modbus:master
+          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /var/lib/octopus/adaptors/
               name: sockets

--- a/adaptors/mqtt/deploy/e2e/all_in_one.yaml
+++ b/adaptors/mqtt/deploy/e2e/all_in_one.yaml
@@ -289,6 +289,7 @@ spec:
     spec:
       containers:
       - image: cnrancher/octopus-adaptor-mqtt:master
+        imagePullPolicy: Always
         name: octopus
         volumeMounts:
         - mountPath: /var/lib/octopus/adaptors/

--- a/adaptors/mqtt/deploy/manifests/workload/daemonset.yaml
+++ b/adaptors/mqtt/deploy/manifests/workload/daemonset.yaml
@@ -19,6 +19,7 @@ spec:
       containers:
         - name: octopus
           image: cnrancher/octopus-adaptor-mqtt:master
+          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /var/lib/octopus/adaptors/
               name: sockets

--- a/adaptors/opcua/deploy/e2e/all_in_one.yaml
+++ b/adaptors/opcua/deploy/e2e/all_in_one.yaml
@@ -760,6 +760,7 @@ spec:
     spec:
       containers:
       - image: cnrancher/octopus-adaptor-opcua:master
+        imagePullPolicy: Always
         name: octopus
         volumeMounts:
         - mountPath: /var/lib/octopus/adaptors/

--- a/adaptors/opcua/deploy/manifests/workload/daemonset.yaml
+++ b/adaptors/opcua/deploy/manifests/workload/daemonset.yaml
@@ -21,6 +21,7 @@ spec:
       containers:
         - name: octopus
           image: cnrancher/octopus-adaptor-opcua:master
+          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /var/lib/octopus/adaptors/
               name: sockets

--- a/template/adaptor/deploy/e2e/all_in_one.yaml
+++ b/template/adaptor/deploy/e2e/all_in_one.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
     devices.edge.cattle.io/description: ""
     devices.edge.cattle.io/device-property: '{"name":"string","dataType":"string","value":"string","updatedAt":"date"}'
     devices.edge.cattle.io/enable: "true"
@@ -128,6 +127,7 @@ spec:
     spec:
       containers:
       - image: cnrancher/octopus-adaptor-template:master
+        imagePullPolicy: Always
         name: octopus
         volumeMounts:
         - mountPath: /var/lib/octopus/adaptors/

--- a/template/adaptor/deploy/manifests/crd/base/devices.edge.cattle.io_templatedevices.yaml
+++ b/template/adaptor/deploy/manifests/crd/base/devices.edge.cattle.io_templatedevices.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    {}
   creationTimestamp: null
   name: templatedevices.devices.edge.cattle.io
 spec:

--- a/template/adaptor/deploy/manifests/workload/daemonset.yaml
+++ b/template/adaptor/deploy/manifests/workload/daemonset.yaml
@@ -19,6 +19,7 @@ spec:
       containers:
         - name: octopus
           image: cnrancher/octopus-adaptor-template:master
+          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /var/lib/octopus/adaptors/
               name: sockets


### PR DESCRIPTION
<!-- [1] Please search for existing PR first, the duplicate PR may not be received.
If the PR has the same fix/enhancement as other, please related them together and explain in step [5].
-->

<!-- [2] Please do not create a PR without creating an issue first.
List issues to be fixed.
-->
**Fixes:**
Set adaptors default image pull policy to always since the `master` tag is used as the default one.

<!-- [3] Describe what the PR fixes or enhances. -->
**Problem:**
the default image pullPolicy is `IfNotPresent` and will not auto fetch the latest image when new master version get released.

<!-- [4] Describe what the PR does. -->
**Solution:**
Set adaptors default image pull policy to always since the `master` tag is used as the default one.


<!-- [5] Describe the plan for regression testing, if no, just write "None" in here.-->
**Test plan:**
N/A

