### PR TITLE
feat: add simulator for adaptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,13 @@ $ helm install --namespace octopus-system octopus octopus/octopus
 ## Source code
 Octopus is 100% open source software. Project source code is spread across a number of repos:
 
-1. Octopus UI -- https://github.com/cnrancher/octopus-ui
-1. Octopus API Server --  https://github.com/cnrancher/octopus-api-server
-1. Octopus Chart -- https://github.com/cnrancher/octopus-chart
-1. Octopus Docs -- https://github.com/cnrancher/docs-octopus
+| Name | Repo Address |
+|:---|:---|
+| Octopus UI | https://github.com/cnrancher/octopus-ui |
+| Octopus API Server | https://github.com/cnrancher/octopus-api-server |
+| Octopus Chart | https://github.com/cnrancher/octopus-chart |
+| Octopus Simulator | https://github.com/cnrancher/octopus-simulator |
+| Octopus Docs | https://github.com/cnrancher/docs-octopus |
 
 ## License
 Copyright (c) 2020 [Rancher Labs, Inc.](http://rancher.com)

--- a/adaptors/modbus/deploy/e2e/dl_modbus_rtu.yaml
+++ b/adaptors/modbus/deploy/e2e/dl_modbus_rtu.yaml
@@ -1,7 +1,7 @@
 apiVersion: edge.cattle.io/v1alpha1
 kind: DeviceLink
 metadata:
-  name: modbus-rtu
+  name: thermometer-rtu
 spec:
   adaptor:
     node: edge-worker
@@ -20,52 +20,65 @@ spec:
       protocol:
         rtu:
           # replace the serial port if needed
-          endpoint: /dev/pts/0
+          endpoint: /dev/ttyS001
           workerID: 1
           parity: "N"
-          stopBits: 1
+          stopBits: 2
           dataBits: 8
-          baudRate: 9600
+          baudRate: 19200
       properties:
         - name: temperature
-          description: temperature value, should be divided by 10
+          description: temperature value in celsius degree.
           readOnly: true
           visitor:
             register: HoldingRegister
             offset: 0
-            quantity: 1
+            quantity: 2
             orderOfOperations:
+              # the source is integer value with 2 quantity,
+              # change to float value.
               - type: Divide
-                value: "10"
+                value: "100"
+              # the source is kevin temperature,
+              # change to celsius degree.
+              - type: Subtract
+                value: "273.15"
           type: float
-        - name: humidity
-          description: humidity value, should be divided by 10
+        - name: humidity-percent
+          description: humidity value, the source is relative humidity.
           readOnly: true
           visitor:
             register: HoldingRegister
             offset: 1
             quantity: 1
             orderOfOperations:
+              # the source is integer value with 2 quantity,
+              # change to float value.
               - type: Divide
-                value: "10"
+                value: "100"
           type: float
-        - name: alert
-          description: the value reaches alert limitation
+        - name: hight-temperature-alarm
+          description: reports alarm if the temperature reaches temperature-limitation.
           readOnly: true
           visitor:
             register: CoilRegister
             offset: 0
             quantity: 1
           type: boolean
-        - name: limitation
-          description: the limitation
+        - name: temperature-limitation
+          description: the limiation of temperature value in celsius degree.
           readOnly: false
-          value: "200"
           visitor:
             register: HoldingRegister
             offset: 5
-            quantity: 1
+            quantity: 2
             orderOfOperations:
+              # the source is integer value with 2 quantity,
+              # change to float value.
               - type: Divide
-                value: "10"
+                value: "100"
+              # the source is kevin temperature,
+              # change to celsius degree.
+              - type: Subtract
+                value: "273.15"
           type: float

--- a/adaptors/modbus/deploy/e2e/dl_modbus_tcp.yaml
+++ b/adaptors/modbus/deploy/e2e/dl_modbus_tcp.yaml
@@ -1,7 +1,7 @@
 apiVersion: edge.cattle.io/v1alpha1
 kind: DeviceLink
 metadata:
-  name: modbus-tcp
+  name: thermometer-tcp
 spec:
   adaptor:
     node: edge-worker
@@ -19,48 +19,61 @@ spec:
       protocol:
         tcp:
           # replace the ip:port address if needed
-          endpoint: 192.168.1.3:5020
+          endpoint: octopus-simulator-modbus-tcp.octopus-simulator-system:5020
           workerID: 1
       properties:
         - name: temperature
-          description: temperature value, should be divided by 10
+          description: temperature value in celsius degree.
           readOnly: true
           visitor:
             register: HoldingRegister
             offset: 0
-            quantity: 1
+            quantity: 2
             orderOfOperations:
+              # the source is integer value with 2 quantity,
+              # change to float value.
               - type: Divide
-                value: "10"
+                value: "100"
+              # the source is kevin temperature,
+              # change to celsius degree.
+              - type: Subtract
+                value: "273.15"
           type: float
-        - name: humidity
-          description: humidity value, should be divided by 10
+        - name: humidity-percent
+          description: humidity value, the source is relative humidity.
           readOnly: true
           visitor:
             register: HoldingRegister
             offset: 1
             quantity: 1
             orderOfOperations:
+              # the source is integer value with 2 quantity,
+              # change to float value.
               - type: Divide
-                value: "10"
+                value: "100"
           type: float
-        - name: alert
-          description: the value reaches alert limitation
+        - name: hight-temperature-alarm
+          description: reports alarm if the temperature reaches temperature-limitation.
           readOnly: true
           visitor:
             register: CoilRegister
             offset: 0
             quantity: 1
           type: boolean
-        - name: limitation
-          description: the limitation
+        - name: temperature-limitation
+          description: the limiation of temperature value in celsius degree.
           readOnly: false
-          value: "20"
           visitor:
             register: HoldingRegister
             offset: 5
-            quantity: 1
+            quantity: 2
             orderOfOperations:
+              # the source is integer value with 2 quantity,
+              # change to float value.
               - type: Divide
-                value: "10"
+                value: "100"
+              # the source is kevin temperature,
+              # change to celsius degree.
+              - type: Subtract
+                value: "273.15"
           type: float

--- a/adaptors/modbus/deploy/e2e/dl_modbus_tcp_with_mqtt.yaml
+++ b/adaptors/modbus/deploy/e2e/dl_modbus_tcp_with_mqtt.yaml
@@ -1,7 +1,7 @@
 apiVersion: edge.cattle.io/v1alpha1
 kind: DeviceLink
 metadata:
-  name: modbus-tcp
+  name: thermometer-tcp
 spec:
   adaptor:
     node: edge-worker
@@ -27,48 +27,61 @@ spec:
       protocol:
         tcp:
           # replace the ip:port address if needed
-          endpoint: 192.168.1.3:5020
+          endpoint: octopus-simulator-modbus-tcp.octopus-simulator-system:5020
           workerID: 1
       properties:
         - name: temperature
-          description: temperature value, should be divided by 10
+          description: temperature value in celsius degree.
           readOnly: true
           visitor:
             register: HoldingRegister
             offset: 0
-            quantity: 1
+            quantity: 2
             orderOfOperations:
+              # the source is integer value with 2 quantity,
+              # change to float value.
               - type: Divide
-                value: "10"
+                value: "100"
+              # the source is kevin temperature,
+              # change to celsius degree.
+              - type: Subtract
+                value: "273.15"
           type: float
-        - name: humidity
-          description: humidity value, should be divided by 10
+        - name: humidity-percent
+          description: humidity value, the source is relative humidity.
           readOnly: true
           visitor:
             register: HoldingRegister
             offset: 1
             quantity: 1
             orderOfOperations:
+              # the source is integer value with 2 quantity,
+              # change to float value.
               - type: Divide
-                value: "10"
+                value: "100"
           type: float
-        - name: alert
-          description: the value reaches alert limitation
+        - name: hight-temperature-alarm
+          description: reports alarm if the temperature reaches temperature-limitation.
           readOnly: true
           visitor:
             register: CoilRegister
             offset: 0
             quantity: 1
           type: boolean
-        - name: limitation
-          description: the limitation
+        - name: temperature-limitation
+          description: the limiation of temperature value in celsius degree.
           readOnly: false
-          value: "20"
           visitor:
             register: HoldingRegister
             offset: 5
-            quantity: 1
+            quantity: 2
             orderOfOperations:
+              # the source is integer value with 2 quantity,
+              # change to float value.
               - type: Divide
-                value: "10"
+                value: "100"
+              # the source is kevin temperature,
+              # change to celsius degree.
+              - type: Subtract
+                value: "273.15"
           type: float

--- a/adaptors/modbus/deploy/e2e/simulator.yaml
+++ b/adaptors/modbus/deploy/e2e/simulator.yaml
@@ -1,0 +1,142 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/name: octopus
+    app.kubernetes.io/version: master
+  name: octopus-simulator-system
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: modbus-tcp
+    app.kubernetes.io/name: octopus
+    app.kubernetes.io/version: master
+  name: octopus-simulator-modbus-tcp
+  namespace: octopus-simulator-system
+spec:
+  ports:
+    - name: tcp
+      port: 5020
+      targetPort: tcp
+  selector:
+    app.kubernetes.io/component: modbus-tcp
+    app.kubernetes.io/name: octopus
+    app.kubernetes.io/version: master
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: modbus-tcp
+    app.kubernetes.io/name: octopus
+    app.kubernetes.io/version: master
+  name: octopus-simulator-modbus-tcp
+  namespace: octopus-simulator-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: modbus-tcp
+      app.kubernetes.io/name: octopus
+      app.kubernetes.io/version: master
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: modbus-tcp
+        app.kubernetes.io/name: octopus
+        app.kubernetes.io/version: master
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: beta.kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+      containers:
+        - args:
+            - modbus
+            - tcp
+          image: cnrancher/octopus-simulator:master
+          imagePullPolicy: Always
+          name: simulator
+          ports:
+            - containerPort: 5020
+              name: tcp
+      terminationGracePeriodSeconds: 30
+
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/component: modbus-rtu
+    app.kubernetes.io/name: octopus
+    app.kubernetes.io/version: master
+  name: octopus-simulator-modbus-rtu
+  namespace: octopus-simulator-system
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: modbus-rtu
+      app.kubernetes.io/name: octopus
+      app.kubernetes.io/version: master
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: modbus-rtu
+        app.kubernetes.io/name: octopus
+        app.kubernetes.io/version: master
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: beta.kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+      containers:
+        - args:
+            - -d
+            - -d
+            - pty,raw,echo=0,link=/dev/ttyS001
+            - pty,raw,echo=0,link=/dev/ttyS002
+          image: alpine/socat:1.7.3.4-r0
+          name: socat
+          volumeMounts:
+            - mountPath: /dev
+              name: dev
+        - args:
+            - modbus
+            - rtu
+          image: cnrancher/octopus-simulator:master
+          imagePullPolicy: Always
+          name: simulator
+          volumeMounts:
+            - mountPath: /dev
+              name: dev
+      terminationGracePeriodSeconds: 30
+      tolerations:
+        - operator: Exists
+      volumes:
+        - hostPath:
+            path: /dev
+            type: Directory
+          name: dev

--- a/adaptors/mqtt/deploy/e2e/dl_attributed_message_bedroom_light.yaml
+++ b/adaptors/mqtt/deploy/e2e/dl_attributed_message_bedroom_light.yaml
@@ -17,14 +17,13 @@ spec:
       protocol:
         pattern: "AttributedMessage"
         client:
-          server: "tcp://test.mosquitto.org:1883"
+          server: "tcp://octopus-simulator-mqtt.octopus-simulator-system:1883"
         message:
           topic: "cattle.io/octopus/home/bedroom/light/:operator"
           operator:
             write: "set"
       properties:
         - name: "switch"
-          path: "switch"
           description: "The switch of light"
           type: "boolean"
           readOnly: false

--- a/adaptors/mqtt/deploy/e2e/dl_attributed_topic_kitchen_door.yaml
+++ b/adaptors/mqtt/deploy/e2e/dl_attributed_topic_kitchen_door.yaml
@@ -17,59 +17,27 @@ spec:
       protocol:
         pattern: "AttributedTopic"
         client:
-          server: "tcp://test.mosquitto.org:1883"
+          server: "tcp://octopus-simulator-mqtt.octopus-simulator-system:1883"
         message:
           topic: "cattle.io/octopus/home/status/kitchen/door/:path"
       properties:
         - name: "state"
-          path: "state"
           description: "The state of door"
           type: "string"
           annotations:
             type: "enum"
             format: "open,close"
         - name: "width"
-          path: "width"
           description: "The width of door"
           type: "float"
           annotations:
             unit: "meter"
         - name: "height"
-          path: "height"
           description: "The height of door"
           type: "float"
           annotations: 
             unit: "meter"
         - name: "material"
-          path: "material"
+          path: "production_material"
           description: "The material of light"
           type: "string"
-    # status:
-    #   properties:
-    #     - name: "state"
-    #       path: "state"
-    #       description: "The state of door"
-    #       type: "string"
-    #       value: "open"
-    #       annotations:
-    #         type: "enum"
-    #         format: "open,close"
-    #     - name: "width"
-    #       path: "width"
-    #       description: "The width of door"
-    #       type: "float"
-    #       value: "1.2"
-    #       annotations:
-    #         unit: "meter"
-    #     - name: "height"
-    #       path: "height"
-    #       description: "The height of door"
-    #       type: "float"
-    #       value: "1.8"
-    #       annotations: 
-    #         unit: "meter"
-    #     - name: "material"
-    #       path: "material"
-    #       description: "The material of light"
-    #       type: "string"
-    #       value: "wood"

--- a/adaptors/mqtt/deploy/e2e/dl_attributed_topic_kitchen_light.yaml
+++ b/adaptors/mqtt/deploy/e2e/dl_attributed_topic_kitchen_light.yaml
@@ -17,7 +17,7 @@ spec:
       protocol:
         pattern: "AttributedTopic"
         client:
-          server: "tcp://test.mosquitto.org:1883"
+          server: "tcp://octopus-simulator-mqtt.octopus-simulator-system:1883"
         message:
           topic: "cattle.io/octopus/home/:operator/kitchen/light/:path"
           operator:
@@ -25,19 +25,20 @@ spec:
             write: "set"
       properties:
         - name: "switch"
-          path: "switch"
           description: "The switch of light"
           type: "boolean"
           readOnlye: false
           qos: 2
         - name: "gear"
-          path: "gear"
           description: "The gear of light"
           type: "string"
           readOnlye: false
           annotations:
             type: "enum"
             format: "low,mid,high"
+          operator:
+            read: "get"
+            write: "control"
         - name: "power"
           path: "parameter_power"
           description: "The power of light"
@@ -75,63 +76,3 @@ spec:
             type: "duration"
             standard: "ISO 8601"
             format: "PYYMMDD"
-    # status:
-    #   properties:
-    #     - name: "switch"
-    #       path: "switch"
-    #       description: "The switch of light"
-    #       type: "boolean"
-    #       value: "false"
-    #       readOnlye: false
-    #       qos: 2
-    #     - name: "gear"
-    #       path: "gear"
-    #       description: "The gear of light"
-    #       type: "string"
-    #       value: "low"
-    #       readOnlye: false
-    #       annotations:
-    #         type: "enum"
-    #         format: "low,mid,high"
-    #     - name: "power"
-    #       path: "parameter_power"
-    #       description: "The power of light"
-    #       type: "float"
-    #       value: "3.0"
-    #       annotations:
-    #         group: "parameter"
-    #         unit: "watt"
-    #     - name: "luminance"
-    #       path: "parameter_luminance"
-    #       description: "The luminance of light"
-    #       type: "int"
-    #       value: "245"
-    #       annotations:
-    #         group: "parameter"
-    #         unit: "luminance"
-    #     - name: "manufacturer"
-    #       description: "The manufacturer of light"
-    #       type: "string"
-    #       value: "Rancher Octopus Fake Device"
-    #       annotations:
-    #         group: "production"
-    #     - name: "productionDate"
-    #       path: "production_date"
-    #       description: "The production date of light"
-    #       type: "string"
-    #       value: "2020-07-08T13:24:00.00Z"
-    #       annotations:
-    #         group: "production"
-    #         type: "datetime"
-    #         standard: "ISO 8601"
-    #         format: "YYYY-MM-DDThh:mm:ss.SSZ"
-    #     - name: "serviceLife"
-    #       path: "service_life"
-    #       description: "The service life of light"
-    #       type: "string"
-    #       value: "P1Y0M0D"
-    #       annotations:
-    #         group: "production"
-    #         type: "duration"
-    #         standard: "ISO 8601"
-    #         format: "PYYMMDD"

--- a/adaptors/mqtt/deploy/e2e/dl_attributed_topic_kitchen_monitor.yaml
+++ b/adaptors/mqtt/deploy/e2e/dl_attributed_topic_kitchen_monitor.yaml
@@ -17,7 +17,7 @@ spec:
       protocol:
         pattern: "AttributedTopic"
         client:
-          server: "tcp://test.mosquitto.org:1883"
+          server: "tcp://octopus-simulator-mqtt.octopus-simulator-system:1883"
         message:
           topic: "cattle.io/octopus/home/status/kitchen/:path"
       properties:
@@ -32,19 +32,3 @@ spec:
           description: "The state of light"
           path: "light/switch"
           type: "boolean"
-    # status:
-    #   properties:
-    #     - name: "doorState"
-    #       path: "door/state"
-    #       description: "The state of door"
-    #       type: "string"
-    #       value: "open"
-    #       annotations:
-    #         type: "enum"
-    #         format: "open,close"
-    #     - name: "isLightOn"
-    #       description: "The state of light"
-    #       path: "light/switch"
-    #       type: "boolean"
-    #       value: "false"
-          

--- a/adaptors/mqtt/deploy/e2e/dl_attributed_topic_livingroom_light.yaml
+++ b/adaptors/mqtt/deploy/e2e/dl_attributed_topic_livingroom_light.yaml
@@ -17,7 +17,7 @@ spec:
       protocol:
         pattern: "AttributedTopic"
         client:
-          server: "tcp://test.mosquitto.org:1883"
+          server: "tcp://octopus-simulator-mqtt.octopus-simulator-system:1883"
         message:
           topic: "cattle.io/octopus/home/livingroom/light/:path/:operator"
           operator:
@@ -45,38 +45,3 @@ spec:
           path: "production"
           description: "The production information of light"
           type: "object"
-    # status:
-    #   properties:
-    #     - name: "switch"
-    #       path: "switch"
-    #       description: "The switch of light"
-    #       type: "boolean"
-    #       value: "open"
-    #       readOnly: false
-    #     - name: "gear"
-    #       path: "gear"
-    #       description: "The gear of light"
-    #       type: "string"
-    #       value: "mid"
-    #       readOnly: false
-    #       annotations:
-    #         type: "enum"
-    #         format: "low,mid,high"
-    #     - name: "parameter"
-    #       path: "parameter"
-    #       description: "The parameter information of light"
-    #       type: "array"
-    #       value:
-    #         - name: power
-    #           value: 70.0w
-    #         - name: luminance
-    #           value: 4900lm
-    #     - name: "production"
-    #       path: "production"
-    #       description: "The production information of light"
-    #       type: "object"
-    #       value: 
-    #         manufacturer: "Rancher Octopus Fake Device"
-    #         date: "2020-07-09T13:00:00.00Z"
-    #         serviceLife: "P1Y0M0D"
-

--- a/adaptors/mqtt/deploy/e2e/simulator.yaml
+++ b/adaptors/mqtt/deploy/e2e/simulator.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/name: octopus
+    app.kubernetes.io/version: master
+  name: octopus-simulator-system
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: mqtt
+    app.kubernetes.io/name: octopus
+    app.kubernetes.io/version: master
+  name: octopus-simulator-mqtt
+  namespace: octopus-simulator-system
+spec:
+  ports:
+    - name: tcp
+      port: 1883
+      targetPort: tcp
+  selector:
+    app.kubernetes.io/component: mqtt
+    app.kubernetes.io/name: octopus
+    app.kubernetes.io/version: master
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: mqtt
+    app.kubernetes.io/name: octopus
+    app.kubernetes.io/version: master
+  name: octopus-simulator-mqtt
+  namespace: octopus-simulator-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: mqtt
+      app.kubernetes.io/name: octopus
+      app.kubernetes.io/version: master
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: mqtt
+        app.kubernetes.io/name: octopus
+        app.kubernetes.io/version: master
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: beta.kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+      containers:
+        - args:
+            - mqtt
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          image: cnrancher/octopus-simulator:master
+          imagePullPolicy: Always
+          name: simulator
+          ports:
+            - containerPort: 1883
+              name: tcp
+      terminationGracePeriodSeconds: 30

--- a/adaptors/opcua/deploy/e2e/dl_opcua.yaml
+++ b/adaptors/opcua/deploy/e2e/dl_opcua.yaml
@@ -19,7 +19,7 @@ spec:
         timeout: 10s
       protocol:
         # replace the address if needed
-        endpoint: opc.tcp://10.43.29.71:4840/
+        endpoint: opc.tcp://octopus-simulator-opcua.octopus-simulator-system:4840/
       properties:
         - name: datetime
           description: the current datetime

--- a/adaptors/opcua/deploy/e2e/dl_opcua_with_mqtt.yaml
+++ b/adaptors/opcua/deploy/e2e/dl_opcua_with_mqtt.yaml
@@ -26,7 +26,7 @@ spec:
             topic: "cattle.io/octopus/:namespace/:name"
       protocol:
         # replace the address if needed
-        endpoint: opc.tcp://10.43.29.71:4840/
+        endpoint: opc.tcp://octopus-simulator-opcua.octopus-simulator-system:4840/
       properties:
         - name: datetime
           description: the current datetime

--- a/adaptors/opcua/deploy/e2e/simulator.yaml
+++ b/adaptors/opcua/deploy/e2e/simulator.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/name: octopus
+    app.kubernetes.io/version: master
+  name: octopus-simulator-system
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: opcua
+    app.kubernetes.io/name: octopus
+    app.kubernetes.io/version: master
+  name: octopus-simulator-opcua
+  namespace: octopus-simulator-system
+spec:
+  ports:
+    - name: tcp
+      port: 4840
+      targetPort: tcp
+  selector:
+    app.kubernetes.io/component: opcua
+    app.kubernetes.io/name: octopus
+    app.kubernetes.io/version: master
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: opcua
+    app.kubernetes.io/name: octopus
+    app.kubernetes.io/version: master
+  name: octopus-simulator-opcua
+  namespace: octopus-simulator-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: opcua
+      app.kubernetes.io/name: octopus
+      app.kubernetes.io/version: master
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: opcua
+        app.kubernetes.io/name: octopus
+        app.kubernetes.io/version: master
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: beta.kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+      containers:
+        - image: open62541/open62541:1.0
+          name: simulator
+          ports:
+            - containerPort: 4840
+              name: tcp
+      terminationGracePeriodSeconds: 30


### PR DESCRIPTION
<!-- [1] Please search for existing PR first, the duplicate PR may not be received.
If the PR has the same fix/enhancement as other, please related them together and explain in step [5].
-->

<!-- [2] Please do not create a PR without creating an issue first.
List issues to be fixed.
-->
**Fixes:**

#124

<!-- [3] Describe what the PR fixes or enhances. -->
**Problem:**

We should give a brief about how to test with the [adaptor simulator](https://github.com/cnrancher/octopus-simulator).

<!-- [4] Describe what the PR does. -->
**Solution:**

- Brief simulator usage in README
- Adjust adaptor E2E deployment YAML

<!-- [5] Describe the plan for regression testing, if no, just write "None" in here.-->
**Test plan:**

- Create a local K3d cluster with [cluster-k3d-spinup.sh](https://github.com/cnrancher/octopus/blob/master/hack/cluster-k3d-spinup.sh)
- Deploy the corresponding `deploy/e2e/simulator.yaml` of the adaptor.
- Deploy the corresponding `deploy/e2e/dl_*.yaml` of the adaptor.
